### PR TITLE
Improve error for binary .brd files

### DIFF
--- a/crates/pcb-extract/src/parsers/eagle.rs
+++ b/crates/pcb-extract/src/parsers/eagle.rs
@@ -6,8 +6,13 @@ use std::collections::HashMap;
 
 /// Parse an Eagle/Fusion360 .brd/.fbrd file into PcbData.
 pub fn parse(data: &[u8], opts: &ExtractOptions) -> Result<PcbData, ExtractError> {
-    let text = std::str::from_utf8(data)
-        .map_err(|e| ExtractError::ParseError(format!("Invalid UTF-8: {e}")))?;
+    let text = std::str::from_utf8(data).map_err(|_| {
+        ExtractError::ParseError(
+            "File appears to be a binary PCB format (possibly Cadence Allegro). \
+             Only Eagle XML .brd files are supported."
+                .to_string(),
+        )
+    })?;
     let parse_opts = roxmltree::ParsingOptions {
         allow_dtd: true,
         ..roxmltree::ParsingOptions::default()


### PR DESCRIPTION
## Summary
- Detects when a `.brd` file is binary (non-UTF-8) in the Eagle parser and returns a clear error message indicating it's likely a Cadence Allegro file
- Previously, binary `.brd` files produced a confusing "Invalid UTF-8" error since both Eagle and Cadence Allegro share the `.brd` extension

Closes #3

## Test plan
- [ ] Upload a Cadence Allegro `.brd` file and verify the error message mentions binary/Allegro format
- [ ] Upload an Eagle XML `.brd` file and verify it still parses correctly
- [ ] `cargo test` passes (196 tests)