### PR TITLE
Add footer and Terms of Service page

### DIFF
--- a/crates/server/src/routes.rs
+++ b/crates/server/src/routes.rs
@@ -87,6 +87,7 @@ pub fn router() -> Router<AppState> {
     const MAX_UPLOAD: usize = 50 * 1024 * 1024;
     Router::new()
         .route("/", get(index))
+        .route("/terms", get(terms))
         .route("/upload", post(upload))
         .route("/api/recent", get(get_recent))
         .route("/b/{id}", get(get_bom))
@@ -99,6 +100,10 @@ pub fn router() -> Router<AppState> {
 
 async fn index() -> Html<&'static str> {
     Html(include_str!("../static/index.html"))
+}
+
+async fn terms() -> Html<&'static str> {
+    Html(include_str!("../static/terms.html"))
 }
 
 #[derive(Serialize)]

--- a/crates/server/static/index.html
+++ b/crates/server/static/index.html
@@ -367,5 +367,11 @@
             }
         }
     </script>
+
+    <footer style="margin-top:3rem;padding:1.5rem 0;border-top:1px solid #2a2a4e;text-align:center;font-size:0.85rem;color:#666;">
+        <a href="https://github.com/meawoppl/pastebom.com" style="color:#4ecca3;text-decoration:none;margin:0 1rem;">GitHub</a>
+        <a href="https://github.com/meawoppl/pastebom.com/issues/new" style="color:#4ecca3;text-decoration:none;margin:0 1rem;">&#x1F41B; Report a Bug</a>
+        <a href="/terms" style="color:#4ecca3;text-decoration:none;margin:0 1rem;">Terms of Service</a>
+    </footer>
 </body>
 </html>

--- a/crates/server/static/terms.html
+++ b/crates/server/static/terms.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Terms of Service - PasteBOM</title>
+    <style>
+        * { box-sizing: border-box; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            margin: 0 auto;
+            padding: 2rem;
+            background: #1a1a2e;
+            color: #eee;
+            min-height: 100vh;
+            max-width: 800px;
+        }
+        h1 { color: #4ecca3; margin-bottom: 0.5rem; }
+        h1 a { color: #4ecca3; text-decoration: none; }
+        h1 a:hover { text-decoration: underline; }
+        h2 { color: #4ecca3; font-size: 1.2rem; margin-top: 2rem; }
+        p, li { line-height: 1.7; color: #ccc; }
+        a { color: #4ecca3; }
+        ul { padding-left: 1.5rem; }
+        li { margin-bottom: 0.5rem; }
+        .back { margin-bottom: 2rem; display: inline-block; }
+        footer {
+            margin-top: 3rem;
+            padding: 1.5rem 0;
+            border-top: 1px solid #2a2a4e;
+            text-align: center;
+            font-size: 0.85rem;
+            color: #666;
+        }
+        footer a { color: #4ecca3; text-decoration: none; margin: 0 1rem; }
+    </style>
+</head>
+<body>
+    <a href="/" class="back">&larr; Back to PasteBOM</a>
+    <h1>Terms of Service</h1>
+
+    <h2>What PasteBOM Does</h2>
+    <p>PasteBOM lets you upload PCB files and generates a shareable link to an interactive BOM viewer. It is a convenience tool, not a secure file vault.</p>
+
+    <h2>Uploads Are Public</h2>
+    <p>All uploaded files are accessible to anyone who has the link. There is no password protection or access control. Marking an upload as "secret" only hides it from the public feed &mdash; the link itself is still accessible to anyone.</p>
+    <p>Treat every upload as if it were publicly visible. Do not upload files containing sensitive information you would not want others to see.</p>
+
+    <h2>Intellectual Property</h2>
+    <ul>
+        <li>Only upload files you have the right to share.</li>
+        <li>Do not upload files that belong to someone else without their permission.</li>
+        <li>Be mindful of proprietary designs, trade secrets, or files covered by NDAs.</li>
+        <li>You are solely responsible for ensuring you have the necessary rights to share any file you upload.</li>
+    </ul>
+
+    <h2>No Guarantees</h2>
+    <p>PasteBOM is provided as-is. Uploads may be deleted at any time without notice. Do not use PasteBOM as your only copy of any file.</p>
+
+    <h2>Abuse</h2>
+    <p>We reserve the right to remove any upload and block access for any reason, including misuse of the service.</p>
+
+    <footer>
+        <a href="https://github.com/meawoppl/pastebom.com">GitHub</a>
+        <a href="https://github.com/meawoppl/pastebom.com/issues/new">&#x1F41B; Report a Bug</a>
+        <a href="/terms">Terms of Service</a>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Added a footer to the landing page with links to GitHub repo, bug reporting, and Terms of Service
- Added a new `/terms` route serving a Terms of Service page
- ToS covers: uploads are publicly accessible via link, IP/licensing responsibilities, no guarantees, and abuse policy

## Test plan
- [ ] Visit `/` and verify footer appears with three links (GitHub, bug report, Terms of Service)
- [ ] Click the Terms of Service link and verify `/terms` loads correctly
- [ ] Verify the ToS page has a back link to the homepage
- [ ] Verify styling matches the existing dark theme