### PR TITLE
Add ZIP/tar bomb detection for archives

### DIFF
--- a/crates/pcb-extract/src/error.rs
+++ b/crates/pcb-extract/src/error.rs
@@ -19,4 +19,7 @@ pub enum ExtractError {
 
     #[error("ZIP error: {0}")]
     Zip(#[from] zip::result::ZipError),
+
+    #[error("decompression bomb detected: decompressed content exceeds safe size limit")]
+    DecompressionBomb,
 }

--- a/crates/pcb-extract/src/lib.rs
+++ b/crates/pcb-extract/src/lib.rs
@@ -8,6 +8,10 @@ use error::ExtractError;
 use std::path::Path;
 use types::PcbData;
 
+/// Maximum total decompressed size for archive contents (500 MB).
+/// Prevents ZIP/tar bomb attacks where a small compressed file expands to exhaust memory.
+pub const MAX_DECOMPRESSED_BYTES: u64 = 500 * 1024 * 1024;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PcbFormat {
     KiCad,

--- a/crates/pcb-extract/src/parsers/gerber/mod.rs
+++ b/crates/pcb-extract/src/parsers/gerber/mod.rs
@@ -20,26 +20,44 @@ use self::layers::GerberLayerType;
 
 /// Parse a zip file containing Gerber files into PcbData.
 pub fn parse(data: &[u8], opts: &ExtractOptions) -> Result<PcbData, ExtractError> {
+    parse_with_limit(data, opts, crate::MAX_DECOMPRESSED_BYTES)
+}
+
+fn parse_with_limit(
+    data: &[u8],
+    opts: &ExtractOptions,
+    max_decompressed: u64,
+) -> Result<PcbData, ExtractError> {
     let cursor = Cursor::new(data);
     let mut archive = zip::ZipArchive::new(cursor)?;
 
     let mut layer_outputs: Vec<(GerberLayerType, GerberLayerOutput)> = Vec::new();
     let mut had_gerber = false;
+    let mut total_decompressed: u64 = 0;
 
     for i in 0..archive.len() {
-        let mut file = archive.by_index(i)?;
+        let file = archive.by_index(i)?;
         if file.is_dir() {
             continue;
         }
 
         let filename = file.name().to_string();
 
-        // Read file content
+        // Read file content with decompression bomb protection
+        let remaining = max_decompressed.saturating_sub(total_decompressed);
         let mut content = String::new();
         use std::io::Read;
-        if file.read_to_string(&mut content).is_err() {
+        if file
+            .take(remaining + 1)
+            .read_to_string(&mut content)
+            .is_err()
+        {
             // Binary file or encoding error — skip
             continue;
+        }
+        total_decompressed += content.len() as u64;
+        if total_decompressed > max_decompressed {
+            return Err(ExtractError::DecompressionBomb);
         }
 
         // Try to parse as Gerber first, then fall back to Excellon drill
@@ -604,5 +622,40 @@ M30
             }
             _ => panic!("Expected Circle"),
         }
+    }
+
+    #[test]
+    fn test_decompression_bomb_rejected() {
+        // Create a ZIP whose decompressed content exceeds a small limit.
+        let content = "X".repeat(2048); // 2 KB of text
+        let zip_data = make_test_zip(&[("bomb.gtl", &content)]);
+        let opts = ExtractOptions::default();
+        // Use a limit smaller than the content to trigger bomb detection
+        let result = parse_with_limit(&zip_data, &opts, 1024);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, ExtractError::DecompressionBomb),
+            "expected DecompressionBomb error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_decompression_within_limit_succeeds() {
+        // Same content but with a generous limit should not trigger bomb detection
+        let gerber = "\
+%FSLAX24Y24*%
+%MOMM*%
+%ADD10C,0.200*%
+G01*
+D10*
+X10000Y10000D02*
+X40000Y10000D01*
+M02*
+";
+        let zip_data = make_test_zip(&[("board.GTL", gerber)]);
+        let opts = ExtractOptions::default();
+        let result = parse_with_limit(&zip_data, &opts, 1024 * 1024);
+        assert!(result.is_ok());
     }
 }

--- a/crates/pcb-extract/src/parsers/odbpp/mod.rs
+++ b/crates/pcb-extract/src/parsers/odbpp/mod.rs
@@ -564,26 +564,39 @@ fn compute_bbox(edges: &[Drawing]) -> BBox {
 
 /// Try extracting as .tgz first, then fall back to .zip.
 fn extract_archive(data: &[u8]) -> Result<HashMap<String, Vec<u8>>, ExtractError> {
-    extract_tar_gz(data).or_else(|_| extract_zip(data))
+    let limit = crate::MAX_DECOMPRESSED_BYTES;
+    extract_tar_gz(data, limit).or_else(|_| extract_zip(data, limit))
 }
 
 /// Extract all files from a .zip archive into memory.
-fn extract_zip(data: &[u8]) -> Result<HashMap<String, Vec<u8>>, ExtractError> {
+fn extract_zip(
+    data: &[u8],
+    max_decompressed: u64,
+) -> Result<HashMap<String, Vec<u8>>, ExtractError> {
     let reader = std::io::Cursor::new(data);
     let mut archive = zip::ZipArchive::new(reader)
         .map_err(|e| ExtractError::ParseError(format!("Failed to read ZIP archive: {e}")))?;
     let mut files = HashMap::new();
+    let mut total_decompressed: u64 = 0;
 
     for i in 0..archive.len() {
-        let mut entry = archive
+        let entry = archive
             .by_index(i)
             .map_err(|e| ExtractError::ParseError(format!("Failed to read ZIP entry: {e}")))?;
         if entry.is_file() {
             let name = entry.name().to_string();
+            let remaining = max_decompressed.saturating_sub(total_decompressed);
             let mut content = Vec::new();
-            entry.read_to_end(&mut content).map_err(|e| {
-                ExtractError::ParseError(format!("Failed to read ZIP entry content: {e}"))
-            })?;
+            entry
+                .take(remaining + 1)
+                .read_to_end(&mut content)
+                .map_err(|e| {
+                    ExtractError::ParseError(format!("Failed to read ZIP entry content: {e}"))
+                })?;
+            total_decompressed += content.len() as u64;
+            if total_decompressed > max_decompressed {
+                return Err(ExtractError::DecompressionBomb);
+            }
             files.insert(name, content);
         }
     }
@@ -592,10 +605,14 @@ fn extract_zip(data: &[u8]) -> Result<HashMap<String, Vec<u8>>, ExtractError> {
 }
 
 /// Extract all files from a .tgz archive into memory.
-fn extract_tar_gz(data: &[u8]) -> Result<HashMap<String, Vec<u8>>, ExtractError> {
+fn extract_tar_gz(
+    data: &[u8],
+    max_decompressed: u64,
+) -> Result<HashMap<String, Vec<u8>>, ExtractError> {
     let gz = flate2::read::GzDecoder::new(data);
     let mut archive = tar::Archive::new(gz);
     let mut files = HashMap::new();
+    let mut total_decompressed: u64 = 0;
 
     for entry in archive
         .entries()
@@ -610,10 +627,18 @@ fn extract_tar_gz(data: &[u8]) -> Result<HashMap<String, Vec<u8>>, ExtractError>
             .to_string();
 
         if entry.header().entry_type().is_file() {
+            let remaining = max_decompressed.saturating_sub(total_decompressed);
             let mut content = Vec::new();
-            entry.read_to_end(&mut content).map_err(|e| {
-                ExtractError::ParseError(format!("Failed to read tar entry content: {e}"))
-            })?;
+            (&mut entry)
+                .take(remaining + 1)
+                .read_to_end(&mut content)
+                .map_err(|e| {
+                    ExtractError::ParseError(format!("Failed to read tar entry content: {e}"))
+                })?;
+            total_decompressed += content.len() as u64;
+            if total_decompressed > max_decompressed {
+                return Err(ExtractError::DecompressionBomb);
+            }
             files.insert(path, content);
         }
     }


### PR DESCRIPTION
## Summary
- Track cumulative decompressed bytes across all entries in ZIP and tar.gz archives
- Use `Read::take()` to bound per-file reads, so memory usage is capped even for malicious files
- Reject archives exceeding 500 MB decompressed (`MAX_DECOMPRESSED_BYTES` constant)
- Protects all three archive extraction paths: Gerber ZIP, ODB++ ZIP, and ODB++ tar.gz

Fixes #39

## Test plan
- [x] `cargo test` — 198 tests pass (2 new: bomb rejected + within-limit succeeds)
- [x] `cargo clippy` — clean
- [x] `cargo fmt` — clean