### PR TITLE
Clamp non-finite f64 to 0.0 in serialization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,10 @@ IMPORTANT: Always run `cargo fmt` before committing any code changes!
 - The server exposes the version via `/health` and the upload page displays it
 - When releasing a new version: bump `version` in root `Cargo.toml` and add a new entry to `CHANGELOG.md`
 
+## Rendering
+
+- The interactive viewer (`crates/viewer/src/render.rs`) and the SVG thumbnail generator (`crates/pcb-extract/src/thumbnail.rs`) are separate rendering paths over the same PcbData JSON. When fixing rendering bugs in the viewer, check whether the thumbnail has the same issue and fix it there too.
+
 ## Build Notes
 
 - Viewer requires `wasm32-unknown-unknown` target and `trunk` installed

--- a/crates/pcb-extract/src/lib.rs
+++ b/crates/pcb-extract/src/lib.rs
@@ -5,6 +5,7 @@ pub mod thumbnail;
 pub mod types;
 
 use error::ExtractError;
+use serde::{Deserialize, Serialize};
 use std::path::Path;
 use types::PcbData;
 
@@ -12,7 +13,8 @@ use types::PcbData;
 /// Prevents ZIP/tar bomb attacks where a small compressed file expands to exhaust memory.
 pub const MAX_DECOMPRESSED_BYTES: u64 = 500 * 1024 * 1024;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum PcbFormat {
     KiCad,
     EasyEda,
@@ -20,6 +22,7 @@ pub enum PcbFormat {
     Altium,
     Gerber,
     Gdsii,
+    #[serde(rename = "odbpp")]
     OdbPlusPlus,
 }
 
@@ -127,7 +130,7 @@ pub fn extract_bytes(
         return Err(ExtractError::MacosResourceFork);
     }
 
-    match format {
+    let mut pcb = match format {
         PcbFormat::KiCad => parsers::kicad::parse(data, opts),
         PcbFormat::EasyEda => parsers::easyeda::parse(data, opts),
         PcbFormat::Eagle => parsers::eagle::parse(data, opts),
@@ -135,7 +138,9 @@ pub fn extract_bytes(
         PcbFormat::Gerber => parsers::gerber::parse(data, opts),
         PcbFormat::Gdsii => parsers::gdsii::parse(data, opts),
         PcbFormat::OdbPlusPlus => parsers::odbpp::parse(data, opts),
-    }
+    }?;
+    pcb.format = Some(format);
+    Ok(pcb)
 }
 
 #[cfg(test)]

--- a/crates/pcb-extract/src/parsers/altium/mod.rs
+++ b/crates/pcb-extract/src/parsers/altium/mod.rs
@@ -142,6 +142,7 @@ pub fn parse(data: &[u8], opts: &ExtractOptions) -> Result<PcbData, ExtractError
         drawings,
         footprints,
         metadata: extract_metadata(&board_records),
+        format: None,
         bom,
         ibom_version: None,
         tracks: track_data,

--- a/crates/pcb-extract/src/parsers/altium/mod.rs
+++ b/crates/pcb-extract/src/parsers/altium/mod.rs
@@ -422,38 +422,12 @@ fn build_footprints(
                 }
             }
 
-            // Bounding box
-            let mut bbox = BBox::empty();
-            for pad in &fp_pads {
-                bbox.expand_point(
-                    pad.pos[0] - pad.size[0] / 2.0,
-                    pad.pos[1] - pad.size[1] / 2.0,
-                );
-                bbox.expand_point(
-                    pad.pos[0] + pad.size[0] / 2.0,
-                    pad.pos[1] + pad.size[1] / 2.0,
-                );
-            }
-            if bbox.minx == f64::INFINITY {
-                bbox = BBox {
-                    minx: center[0] - 0.5,
-                    miny: center[1] - 0.5,
-                    maxx: center[0] + 0.5,
-                    maxy: center[1] + 0.5,
-                };
-            }
-
             let side = layer_map.side(comp.layer);
 
             Footprint {
                 ref_: comp.designator.clone(),
                 center,
-                bbox: FootprintBBox {
-                    pos: center,
-                    relpos: [bbox.minx - center[0], bbox.miny - center[1]],
-                    size: [bbox.maxx - bbox.minx, bbox.maxy - bbox.miny],
-                    angle: comp.rotation,
-                },
+                bbox: FootprintBBox::from_pads(&fp_pads, center, comp.rotation),
                 pads: fp_pads,
                 drawings: fp_drawings,
                 layer: side.to_string(),

--- a/crates/pcb-extract/src/parsers/altium/mod.rs
+++ b/crates/pcb-extract/src/parsers/altium/mod.rs
@@ -109,7 +109,7 @@ pub fn parse(data: &[u8], opts: &ExtractOptions) -> Result<PcbData, ExtractError
 
     // 7. Board edges
     let edges = extract_board_edges(&board_records, units_per_mil, scale);
-    let edges_bbox = compute_edges_bbox(&edges);
+    let edges_bbox = BBox::from_drawings(&edges);
 
     // 8. Categorize board-level drawings (silkscreen, fabrication)
     let drawings = categorize_drawings(&tracks, &arcs, &fills, &layer_map, scale);
@@ -856,34 +856,5 @@ fn extract_metadata(board_records: &[HashMap<String, String>]) -> Metadata {
         revision: String::new(),
         company: String::new(),
         date: String::new(),
-    }
-}
-
-// ─── Bbox ────────────────────────────────────────────────────────────
-
-fn compute_edges_bbox(edges: &[Drawing]) -> BBox {
-    let mut bbox = BBox::empty();
-    for edge in edges {
-        match edge {
-            Drawing::Segment { start, end, .. } => {
-                bbox.expand_point(start[0], start[1]);
-                bbox.expand_point(end[0], end[1]);
-            }
-            Drawing::Arc { start, radius, .. } => {
-                bbox.expand_point(start[0] - radius, start[1] - radius);
-                bbox.expand_point(start[0] + radius, start[1] + radius);
-            }
-            _ => {}
-        }
-    }
-    if bbox.minx == f64::INFINITY {
-        BBox {
-            minx: 0.0,
-            miny: 0.0,
-            maxx: 100.0,
-            maxy: 100.0,
-        }
-    } else {
-        bbox
     }
 }

--- a/crates/pcb-extract/src/parsers/eagle.rs
+++ b/crates/pcb-extract/src/parsers/eagle.rs
@@ -86,6 +86,7 @@ pub fn parse(data: &[u8], opts: &ExtractOptions) -> Result<PcbData, ExtractError
             company: String::new(),
             date: String::new(),
         },
+        format: None,
         bom,
         ibom_version: None,
         tracks,

--- a/crates/pcb-extract/src/parsers/eagle.rs
+++ b/crates/pcb-extract/src/parsers/eagle.rs
@@ -462,33 +462,7 @@ fn parse_elements(
                 }
             }
 
-            // Bounding box
-            let mut bbox = BBox::empty();
-            for pad in &fp_pads {
-                bbox.expand_point(
-                    pad.pos[0] - pad.size[0] / 2.0,
-                    pad.pos[1] - pad.size[1] / 2.0,
-                );
-                bbox.expand_point(
-                    pad.pos[0] + pad.size[0] / 2.0,
-                    pad.pos[1] + pad.size[1] / 2.0,
-                );
-            }
-            if bbox.minx == f64::INFINITY {
-                bbox = BBox {
-                    minx: x - 0.5,
-                    miny: -y - 0.5,
-                    maxx: x + 0.5,
-                    maxy: -y + 0.5,
-                };
-            }
-
-            let fp_bbox = FootprintBBox {
-                pos: [x, -y],
-                relpos: [bbox.minx - x, bbox.miny - (-y)],
-                size: [bbox.maxx - bbox.minx, bbox.maxy - bbox.miny],
-                angle,
-            };
+            let fp_bbox = FootprintBBox::from_pads(&fp_pads, [x, -y], angle);
 
             let idx = footprints.len();
 

--- a/crates/pcb-extract/src/parsers/eagle.rs
+++ b/crates/pcb-extract/src/parsers/eagle.rs
@@ -47,7 +47,7 @@ pub fn parse(data: &[u8], opts: &ExtractOptions) -> Result<PcbData, ExtractError
         (Vec::new(), Vec::new())
     };
 
-    let edges_bbox = compute_bbox(&edges);
+    let edges_bbox = BBox::from_drawings(&edges);
     let bom = Some(generate_bom(
         &footprints,
         &components,
@@ -733,36 +733,5 @@ fn mirror_eagle_layer(layer: u32) -> u32 {
         51 => 52,
         52 => 51,
         _ => layer,
-    }
-}
-
-fn compute_bbox(edges: &[Drawing]) -> BBox {
-    let mut bbox = BBox::empty();
-    for edge in edges {
-        match edge {
-            Drawing::Segment { start, end, .. } => {
-                bbox.expand_point(start[0], start[1]);
-                bbox.expand_point(end[0], end[1]);
-            }
-            Drawing::Rect { start, end, .. } => {
-                bbox.expand_point(start[0], start[1]);
-                bbox.expand_point(end[0], end[1]);
-            }
-            Drawing::Circle { start, radius, .. } => {
-                bbox.expand_point(start[0] - radius, start[1] - radius);
-                bbox.expand_point(start[0] + radius, start[1] + radius);
-            }
-            _ => {}
-        }
-    }
-    if bbox.minx == f64::INFINITY {
-        BBox {
-            minx: 0.0,
-            miny: 0.0,
-            maxx: 100.0,
-            maxy: 100.0,
-        }
-    } else {
-        bbox
     }
 }

--- a/crates/pcb-extract/src/parsers/eagle_binary.rs
+++ b/crates/pcb-extract/src/parsers/eagle_binary.rs
@@ -1159,13 +1159,14 @@ mod tests {
         let has_pads = pcb.footprints.iter().any(|fp| !fp.pads.is_empty());
         assert!(has_pads, "Expected at least one footprint with pads");
 
-        // Check bbox is reasonable (not degenerate)
-        let bb = &pcb.edges_bbox;
-        assert!(
-            bb.maxx > bb.minx && bb.maxy > bb.miny,
-            "Expected non-degenerate bounding box, got {:?}",
-            bb
-        );
+        // Check bbox if edges were found
+        if let Some(bb) = &pcb.edges_bbox {
+            assert!(
+                bb.maxx > bb.minx && bb.maxy > bb.miny,
+                "Expected non-degenerate bounding box, got {:?}",
+                bb
+            );
+        }
     }
 
     #[test]

--- a/crates/pcb-extract/src/parsers/eagle_binary.rs
+++ b/crates/pcb-extract/src/parsers/eagle_binary.rs
@@ -370,7 +370,7 @@ fn extract_board(
         (Vec::new(), Vec::new())
     };
 
-    let edges_bbox = compute_bbox(&edges);
+    let edges_bbox = BBox::from_drawings(&edges);
     let bom = Some(generate_bom(
         &footprints,
         &components,
@@ -1143,37 +1143,6 @@ fn rotate_point(x: f64, y: f64, angle: f64, mirror: bool) -> (f64, f64) {
     let cos_a = rad.cos();
     let sin_a = rad.sin();
     (x * cos_a - y * sin_a, x * sin_a + y * cos_a)
-}
-
-fn compute_bbox(edges: &[Drawing]) -> BBox {
-    let mut bbox = BBox::empty();
-    for edge in edges {
-        match edge {
-            Drawing::Segment { start, end, .. } => {
-                bbox.expand_point(start[0], start[1]);
-                bbox.expand_point(end[0], end[1]);
-            }
-            Drawing::Rect { start, end, .. } => {
-                bbox.expand_point(start[0], start[1]);
-                bbox.expand_point(end[0], end[1]);
-            }
-            Drawing::Circle { start, radius, .. } => {
-                bbox.expand_point(start[0] - radius, start[1] - radius);
-                bbox.expand_point(start[0] + radius, start[1] + radius);
-            }
-            _ => {}
-        }
-    }
-    if bbox.minx == f64::INFINITY {
-        BBox {
-            minx: 0.0,
-            miny: 0.0,
-            maxx: 100.0,
-            maxy: 100.0,
-        }
-    } else {
-        bbox
-    }
 }
 
 #[cfg(test)]

--- a/crates/pcb-extract/src/parsers/eagle_binary.rs
+++ b/crates/pcb-extract/src/parsers/eagle_binary.rs
@@ -810,33 +810,7 @@ fn build_footprints(
             }
         }
 
-        // Bounding box
-        let mut bbox = BBox::empty();
-        for pad in &fp_pads {
-            bbox.expand_point(
-                pad.pos[0] - pad.size[0] / 2.0,
-                pad.pos[1] - pad.size[1] / 2.0,
-            );
-            bbox.expand_point(
-                pad.pos[0] + pad.size[0] / 2.0,
-                pad.pos[1] + pad.size[1] / 2.0,
-            );
-        }
-        if bbox.minx == f64::INFINITY {
-            bbox = BBox {
-                minx: x - 0.5,
-                miny: -y - 0.5,
-                maxx: x + 0.5,
-                maxy: -y + 0.5,
-            };
-        }
-
-        let fp_bbox = FootprintBBox {
-            pos: [x, -y],
-            relpos: [bbox.minx - x, bbox.miny - (-y)],
-            size: [bbox.maxx - bbox.minx, bbox.maxy - bbox.miny],
-            angle,
-        };
+        let fp_bbox = FootprintBBox::from_pads(&fp_pads, [x, -y], angle);
 
         let idx = footprints.len();
 

--- a/crates/pcb-extract/src/parsers/eagle_binary.rs
+++ b/crates/pcb-extract/src/parsers/eagle_binary.rs
@@ -409,6 +409,7 @@ fn extract_board(
             company: String::new(),
             date: String::new(),
         },
+        format: None,
         bom,
         ibom_version: None,
         tracks,

--- a/crates/pcb-extract/src/parsers/easyeda.rs
+++ b/crates/pcb-extract/src/parsers/easyeda.rs
@@ -131,6 +131,7 @@ pub fn parse(data: &[u8], opts: &ExtractOptions) -> Result<PcbData, ExtractError
             company: String::new(),
             date: String::new(),
         },
+        format: None,
         bom,
         ibom_version: None,
         tracks,

--- a/crates/pcb-extract/src/parsers/easyeda.rs
+++ b/crates/pcb-extract/src/parsers/easyeda.rs
@@ -92,7 +92,7 @@ pub fn parse(data: &[u8], opts: &ExtractOptions) -> Result<PcbData, ExtractError
         }
     }
 
-    let edges_bbox = compute_bbox(&edges);
+    let edges_bbox = BBox::from_drawings(&edges);
     let bom = Some(generate_bom(
         &footprints,
         &components,
@@ -546,32 +546,5 @@ fn easyeda_layer_to_side(layer_id: u32) -> &'static str {
         2 | 4 | 6 | 13 => "B",
         11 => "F", // Multi-layer, treat as front
         _ => "F",
-    }
-}
-
-fn compute_bbox(edges: &[Drawing]) -> BBox {
-    let mut bbox = BBox::empty();
-    for edge in edges {
-        match edge {
-            Drawing::Segment { start, end, .. } => {
-                bbox.expand_point(start[0], start[1]);
-                bbox.expand_point(end[0], end[1]);
-            }
-            Drawing::Circle { start, radius, .. } => {
-                bbox.expand_point(start[0] - radius, start[1] - radius);
-                bbox.expand_point(start[0] + radius, start[1] + radius);
-            }
-            _ => {}
-        }
-    }
-    if bbox.minx == f64::INFINITY {
-        BBox {
-            minx: 0.0,
-            miny: 0.0,
-            maxx: 100.0,
-            maxy: 100.0,
-        }
-    } else {
-        bbox
     }
 }

--- a/crates/pcb-extract/src/parsers/gdsii.rs
+++ b/crates/pcb-extract/src/parsers/gdsii.rs
@@ -1549,6 +1549,7 @@ pub fn parse(data: &[u8], opts: &ExtractOptions) -> Result<PcbData, ExtractError
             company: String::new(),
             date: String::new(),
         },
+        format: None,
         bom,
         ibom_version: None,
         tracks,

--- a/crates/pcb-extract/src/parsers/gdsii.rs
+++ b/crates/pcb-extract/src/parsers/gdsii.rs
@@ -1524,7 +1524,7 @@ pub fn parse(data: &[u8], opts: &ExtractOptions) -> Result<PcbData, ExtractError
     };
 
     Ok(PcbData {
-        edges_bbox: bbox,
+        edges_bbox: Some(bbox),
         edges,
         drawings: Drawings {
             silkscreen: LayerData {
@@ -1837,14 +1837,15 @@ mod tests {
 
         // Bounding box should be approximately 50mm x 30mm
         // Y is negated, so miny=-30, maxy=0
-        let width = pcb.edges_bbox.maxx - pcb.edges_bbox.minx;
+        let bb = pcb.edges_bbox.as_ref().expect("Expected bounding box");
+        let width = bb.maxx - bb.minx;
         assert!(
             (width - 50.0).abs() < 0.1,
             "Expected width ~50mm, got {}",
             width
         );
 
-        let height = pcb.edges_bbox.maxy - pcb.edges_bbox.miny;
+        let height = bb.maxy - bb.miny;
         assert!(
             (height - 30.0).abs() < 0.1,
             "Expected height ~30mm, got {}",

--- a/crates/pcb-extract/src/parsers/gerber/mod.rs
+++ b/crates/pcb-extract/src/parsers/gerber/mod.rs
@@ -277,7 +277,11 @@ fn assemble_pcb_data(
     };
 
     Ok(PcbData {
-        edges_bbox: bbox,
+        edges_bbox: if bbox.minx.is_finite() {
+            Some(bbox)
+        } else {
+            None
+        },
         edges,
         drawings: Drawings {
             silkscreen: LayerData {
@@ -441,9 +445,10 @@ M02*
         assert_eq!(pcb.edges.len(), 4);
 
         // Bounding box should be ~50x30mm (Y is negated: 0 to -30)
-        assert_abs_diff_eq!(pcb.edges_bbox.maxx, 50.0, epsilon = 0.1);
-        assert_abs_diff_eq!(pcb.edges_bbox.miny, -30.0, epsilon = 0.1);
-        assert_abs_diff_eq!(pcb.edges_bbox.maxy, 0.0, epsilon = 0.1);
+        let bb = pcb.edges_bbox.as_ref().expect("Expected bounding box");
+        assert_abs_diff_eq!(bb.maxx, 50.0, epsilon = 0.1);
+        assert_abs_diff_eq!(bb.miny, -30.0, epsilon = 0.1);
+        assert_abs_diff_eq!(bb.maxy, 0.0, epsilon = 0.1);
 
         // Copper top: 1 track segment
         let tracks = pcb.tracks.unwrap();

--- a/crates/pcb-extract/src/parsers/gerber/mod.rs
+++ b/crates/pcb-extract/src/parsers/gerber/mod.rs
@@ -311,6 +311,7 @@ fn assemble_pcb_data(
             company: String::new(),
             date: String::new(),
         },
+        format: None,
         bom: None,
         ibom_version: None,
         tracks,

--- a/crates/pcb-extract/src/parsers/kicad.rs
+++ b/crates/pcb-extract/src/parsers/kicad.rs
@@ -114,6 +114,7 @@ pub fn parse(data: &[u8], opts: &ExtractOptions) -> Result<PcbData, ExtractError
         },
         footprints,
         metadata,
+        format: None,
         bom,
         ibom_version: None,
         tracks,

--- a/crates/pcb-extract/src/parsers/kicad.rs
+++ b/crates/pcb-extract/src/parsers/kicad.rs
@@ -513,33 +513,7 @@ fn parse_footprint(
         }
     }
 
-    // Compute bounding box from pads
-    let mut bbox = BBox::empty();
-    for pad in &pads {
-        bbox.expand_point(
-            pad.pos[0] - pad.size[0] / 2.0,
-            pad.pos[1] - pad.size[1] / 2.0,
-        );
-        bbox.expand_point(
-            pad.pos[0] + pad.size[0] / 2.0,
-            pad.pos[1] + pad.size[1] / 2.0,
-        );
-    }
-    if bbox.minx == f64::INFINITY {
-        bbox = BBox {
-            minx: fp_x - 0.5,
-            miny: fp_y - 0.5,
-            maxx: fp_x + 0.5,
-            maxy: fp_y + 0.5,
-        };
-    }
-
-    let fp_bbox = FootprintBBox {
-        pos: [fp_x, fp_y],
-        relpos: [bbox.minx - fp_x, bbox.miny - fp_y],
-        size: [bbox.maxx - bbox.minx, bbox.maxy - bbox.miny],
-        angle: fp_angle,
-    };
+    let fp_bbox = FootprintBBox::from_pads(&pads, [fp_x, fp_y], fp_angle);
 
     let comp_side = if side == "B" { Side::Back } else { Side::Front };
 

--- a/crates/pcb-extract/src/parsers/kicad.rs
+++ b/crates/pcb-extract/src/parsers/kicad.rs
@@ -95,7 +95,7 @@ pub fn parse(data: &[u8], opts: &ExtractOptions) -> Result<PcbData, ExtractError
     };
 
     // Compute edges bounding box
-    let edges_bbox = compute_edges_bbox(&edges);
+    let edges_bbox = BBox::from_drawings(&edges);
 
     Ok(PcbData {
         edges_bbox,
@@ -1190,57 +1190,4 @@ fn arc_from_three_points(
     let end_angle = (cy - uy).atan2(cx - ux) * 180.0 / PI;
 
     Some(([ux, uy], radius, start_angle, end_angle))
-}
-
-fn compute_edges_bbox(edges: &[Drawing]) -> BBox {
-    let mut bbox = BBox::empty();
-    for edge in edges {
-        match edge {
-            Drawing::Segment { start, end, .. } => {
-                bbox.expand_point(start[0], start[1]);
-                bbox.expand_point(end[0], end[1]);
-            }
-            Drawing::Rect { start, end, .. } => {
-                bbox.expand_point(start[0], start[1]);
-                bbox.expand_point(end[0], end[1]);
-            }
-            Drawing::Circle { start, radius, .. } => {
-                bbox.expand_point(start[0] - radius, start[1] - radius);
-                bbox.expand_point(start[0] + radius, start[1] + radius);
-            }
-            Drawing::Arc { start, radius, .. } => {
-                bbox.expand_point(start[0] - radius, start[1] - radius);
-                bbox.expand_point(start[0] + radius, start[1] + radius);
-            }
-            Drawing::Curve {
-                start,
-                end,
-                cpa,
-                cpb,
-                ..
-            } => {
-                bbox.expand_point(start[0], start[1]);
-                bbox.expand_point(end[0], end[1]);
-                bbox.expand_point(cpa[0], cpa[1]);
-                bbox.expand_point(cpb[0], cpb[1]);
-            }
-            Drawing::Polygon { polygons, .. } => {
-                for poly in polygons {
-                    for pt in poly {
-                        bbox.expand_point(pt[0], pt[1]);
-                    }
-                }
-            }
-        }
-    }
-    if bbox.minx == f64::INFINITY {
-        BBox {
-            minx: 0.0,
-            miny: 0.0,
-            maxx: 100.0,
-            maxy: 100.0,
-        }
-    } else {
-        bbox
-    }
 }

--- a/crates/pcb-extract/src/parsers/odbpp/mod.rs
+++ b/crates/pcb-extract/src/parsers/odbpp/mod.rs
@@ -56,7 +56,7 @@ pub fn parse(data: &[u8], opts: &ExtractOptions) -> Result<PcbData, ExtractError
         }
     }
 
-    let edges_bbox = compute_bbox(&edges);
+    let edges_bbox = BBox::from_drawings(&edges);
 
     // Parse silkscreen layers
     let mut silk_front = Vec::new();
@@ -509,59 +509,6 @@ fn find_nearest_pad(pads: &[PadFeature], x_mm: f64, y_mm: f64, tol: f64) -> Opti
     best.map(|(_, p)| p.clone())
 }
 
-/// Compute bounding box from edge drawings.
-fn compute_bbox(edges: &[Drawing]) -> BBox {
-    let mut bbox = BBox::empty();
-    for d in edges {
-        match d {
-            Drawing::Segment { start, end, .. } => {
-                bbox.expand_point(start[0], start[1]);
-                bbox.expand_point(end[0], end[1]);
-            }
-            Drawing::Polygon { polygons, .. } => {
-                for poly in polygons {
-                    for pt in poly {
-                        bbox.expand_point(pt[0], pt[1]);
-                    }
-                }
-            }
-            Drawing::Circle { start, radius, .. } => {
-                bbox.expand_point(start[0] - radius, start[1] - radius);
-                bbox.expand_point(start[0] + radius, start[1] + radius);
-            }
-            Drawing::Arc { start, radius, .. } => {
-                bbox.expand_point(start[0] - radius, start[1] - radius);
-                bbox.expand_point(start[0] + radius, start[1] + radius);
-            }
-            Drawing::Rect { start, end, .. } => {
-                bbox.expand_point(start[0], start[1]);
-                bbox.expand_point(end[0], end[1]);
-            }
-            Drawing::Curve {
-                start,
-                end,
-                cpa,
-                cpb,
-                ..
-            } => {
-                bbox.expand_point(start[0], start[1]);
-                bbox.expand_point(end[0], end[1]);
-                bbox.expand_point(cpa[0], cpa[1]);
-                bbox.expand_point(cpb[0], cpb[1]);
-            }
-        }
-    }
-    if bbox.minx == f64::INFINITY {
-        bbox = BBox {
-            minx: 0.0,
-            miny: 0.0,
-            maxx: 100.0,
-            maxy: 100.0,
-        };
-    }
-    bbox
-}
-
 /// Try extracting as .tgz first, then fall back to .zip.
 fn extract_archive(data: &[u8]) -> Result<HashMap<String, Vec<u8>>, ExtractError> {
     let limit = crate::MAX_DECOMPRESSED_BYTES;
@@ -737,7 +684,7 @@ mod tests {
             end: [100.0, 50.0],
             width: 0.0,
         }];
-        let bbox = compute_bbox(&edges);
+        let bbox = BBox::from_drawings(&edges);
         assert_abs_diff_eq!(bbox.minx, 0.0, epsilon = 1e-6);
         assert_abs_diff_eq!(bbox.miny, 0.0, epsilon = 1e-6);
         assert_abs_diff_eq!(bbox.maxx, 100.0, epsilon = 1e-6);

--- a/crates/pcb-extract/src/parsers/odbpp/mod.rs
+++ b/crates/pcb-extract/src/parsers/odbpp/mod.rs
@@ -487,6 +487,7 @@ pub fn parse(data: &[u8], opts: &ExtractOptions) -> Result<PcbData, ExtractError
             company: String::new(),
             date: String::new(),
         },
+        format: None,
         bom,
         ibom_version: None,
         tracks,

--- a/crates/pcb-extract/src/parsers/odbpp/mod.rs
+++ b/crates/pcb-extract/src/parsers/odbpp/mod.rs
@@ -685,7 +685,7 @@ mod tests {
             end: [100.0, 50.0],
             width: 0.0,
         }];
-        let bbox = BBox::from_drawings(&edges);
+        let bbox = BBox::from_drawings(&edges).expect("Expected bounding box");
         assert_abs_diff_eq!(bbox.minx, 0.0, epsilon = 1e-6);
         assert_abs_diff_eq!(bbox.miny, 0.0, epsilon = 1e-6);
         assert_abs_diff_eq!(bbox.maxx, 100.0, epsilon = 1e-6);

--- a/crates/pcb-extract/src/thumbnail.rs
+++ b/crates/pcb-extract/src/thumbnail.rs
@@ -11,7 +11,10 @@ const MARGIN: f64 = 2.0;
 
 /// Render a PcbData into an SVG string suitable for use as a thumbnail.
 pub fn render_svg(data: &PcbData) -> String {
-    let bbox = &data.edges_bbox;
+    let bbox = match &data.edges_bbox {
+        Some(b) => b,
+        None => return empty_svg(),
+    };
     let w = bbox.maxx - bbox.minx;
     let h = bbox.maxy - bbox.miny;
 
@@ -234,16 +237,10 @@ fn render_arc(
 }
 
 fn render_pads(svg: &mut String, fp: &crate::types::Footprint) {
-    let cx = fp.center[0];
-    let cy = fp.center[1];
-    let angle_rad = fp.bbox.angle.to_radians();
-
     for pad in &fp.pads {
-        // Transform pad position from component-local to world coordinates
-        let cos_a = angle_rad.cos();
-        let sin_a = angle_rad.sin();
-        let px = pad.pos[0] * cos_a - pad.pos[1] * sin_a + cx;
-        let py = pad.pos[0] * sin_a + pad.pos[1] * cos_a + cy;
+        // Pad positions are already in absolute world coordinates
+        let px = pad.pos[0];
+        let py = pad.pos[1];
 
         let w = pad.size[0];
         let h = pad.size[1];
@@ -259,13 +256,25 @@ fn render_pads(svg: &mut String, fp: &crate::types::Footprint) {
             }
             _ => {
                 // rect, roundrect, chamfrect, custom → rectangle
-                write!(
-                    svg,
-                    r#"<rect x="{:.4}" y="{:.4}" width="{w:.4}" height="{h:.4}" fill="{PAD_COLOR}"/>"#,
-                    px - w / 2.0,
-                    py - h / 2.0,
-                )
-                .unwrap();
+                let angle = pad.angle.unwrap_or(0.0);
+                if angle.abs() > 0.01 {
+                    write!(
+                        svg,
+                        r#"<rect x="{:.4}" y="{:.4}" width="{w:.4}" height="{h:.4}" fill="{PAD_COLOR}" transform="rotate({:.4} {px:.4} {py:.4})"/>"#,
+                        px - w / 2.0,
+                        py - h / 2.0,
+                        -angle,
+                    )
+                    .unwrap();
+                } else {
+                    write!(
+                        svg,
+                        r#"<rect x="{:.4}" y="{:.4}" width="{w:.4}" height="{h:.4}" fill="{PAD_COLOR}"/>"#,
+                        px - w / 2.0,
+                        py - h / 2.0,
+                    )
+                    .unwrap();
+                }
             }
         }
     }
@@ -333,12 +342,12 @@ mod tests {
 
     fn minimal_pcbdata() -> PcbData {
         PcbData {
-            edges_bbox: BBox {
+            edges_bbox: Some(BBox {
                 minx: 0.0,
                 miny: 0.0,
                 maxx: 50.0,
                 maxy: 30.0,
-            },
+            }),
             edges: vec![
                 Drawing::Segment {
                     start: [0.0, 0.0],
@@ -434,12 +443,20 @@ mod tests {
     #[test]
     fn test_empty_bbox() {
         let mut data = minimal_pcbdata();
-        data.edges_bbox = BBox {
+        data.edges_bbox = Some(BBox {
             minx: 0.0,
             miny: 0.0,
             maxx: 0.0,
             maxy: 0.0,
-        };
+        });
+        let svg = render_svg(&data);
+        assert!(svg.contains("viewBox=\"0 0 100 100\""));
+    }
+
+    #[test]
+    fn test_none_bbox() {
+        let mut data = minimal_pcbdata();
+        data.edges_bbox = None;
         let svg = render_svg(&data);
         assert!(svg.contains("viewBox=\"0 0 100 100\""));
     }
@@ -447,12 +464,12 @@ mod tests {
     #[test]
     fn test_negative_bbox() {
         let mut data = minimal_pcbdata();
-        data.edges_bbox = BBox {
+        data.edges_bbox = Some(BBox {
             minx: 0.0,
             miny: 0.0,
             maxx: -5.0,
             maxy: -5.0,
-        };
+        });
         let svg = render_svg(&data);
         assert!(svg.contains("viewBox=\"0 0 100 100\""));
     }
@@ -468,12 +485,12 @@ mod tests {
     #[test]
     fn test_aspect_ratio_preserved() {
         let mut data = minimal_pcbdata();
-        data.edges_bbox = BBox {
+        data.edges_bbox = Some(BBox {
             minx: 0.0,
             miny: 0.0,
             maxx: 100.0,
             maxy: 50.0,
-        };
+        });
         let svg = render_svg(&data);
         // width=400, height should be 400 * (54/104) ≈ 207.69 (with margin)
         assert!(svg.contains("width=\"400\""));
@@ -499,12 +516,12 @@ mod tests {
     }
 
     #[test]
-    fn test_rotated_pad_position() {
+    fn test_pad_absolute_position() {
         let mut data = minimal_pcbdata();
-        data.footprints[0].bbox.angle = 90.0;
-        data.footprints[0].pads[0].pos = [1.0, 0.0];
+        // Pad positions are stored in absolute world coordinates
+        data.footprints[0].pads[0].pos = [10.0, 5.0];
         let svg = render_svg(&data);
-        assert!(svg.contains("<circle"));
+        assert!(svg.contains(r#"cx="10.0000" cy="5.0000""#));
     }
 
     #[test]
@@ -895,5 +912,11 @@ mod tests {
         assert!(svg.contains("<circle"));
         assert!(svg.contains("<rect"));
         assert!(svg.contains("<path"));
+    }
+
+    #[test]
+    fn test_empty_edges_produce_none_bbox() {
+        let bbox = BBox::from_drawings(&[]);
+        assert!(bbox.is_none());
     }
 }

--- a/crates/pcb-extract/src/thumbnail.rs
+++ b/crates/pcb-extract/src/thumbnail.rs
@@ -409,6 +409,7 @@ mod tests {
                 company: String::new(),
                 date: String::new(),
             },
+            format: None,
             bom: None,
             ibom_version: None,
             tracks: None,

--- a/crates/pcb-extract/src/types.rs
+++ b/crates/pcb-extract/src/types.rs
@@ -45,6 +45,8 @@ pub struct PcbData {
     pub footprints: Vec<Footprint>,
     pub metadata: Metadata,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub format: Option<crate::PcbFormat>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub bom: Option<BomData>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ibom_version: Option<String>,

--- a/crates/pcb-extract/src/types.rs
+++ b/crates/pcb-extract/src/types.rs
@@ -294,6 +294,47 @@ pub struct FootprintBBox {
     pub angle: f64,
 }
 
+impl FootprintBBox {
+    /// Build a bbox from absolute pad positions by un-rotating them into the
+    /// footprint's local coordinate frame.  The viewer applies
+    /// `rotate(-angle)` when drawing the highlight, so storing local-frame
+    /// relpos/size avoids double-rotation.
+    pub fn from_pads(pads: &[Pad], center: [f64; 2], angle: f64) -> Self {
+        let mut bbox = BBox::empty();
+        let angle_rad = angle * std::f64::consts::PI / 180.0;
+        let cos_a = angle_rad.cos();
+        let sin_a = angle_rad.sin();
+
+        for pad in pads {
+            let dx = pad.pos[0] - center[0];
+            let dy = pad.pos[1] - center[1];
+            let (lx, ly) = if angle != 0.0 {
+                (dx * cos_a - dy * sin_a, dx * sin_a + dy * cos_a)
+            } else {
+                (dx, dy)
+            };
+            bbox.expand_point(lx - pad.size[0] / 2.0, ly - pad.size[1] / 2.0);
+            bbox.expand_point(lx + pad.size[0] / 2.0, ly + pad.size[1] / 2.0);
+        }
+
+        if !bbox.minx.is_finite() {
+            bbox = BBox {
+                minx: -0.5,
+                miny: -0.5,
+                maxx: 0.5,
+                maxy: 0.5,
+            };
+        }
+
+        FootprintBBox {
+            pos: center,
+            relpos: [bbox.minx, bbox.miny],
+            size: [bbox.maxx - bbox.minx, bbox.maxy - bbox.miny],
+            angle,
+        }
+    }
+}
+
 // ─── Pad ─────────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/pcb-extract/src/types.rs
+++ b/crates/pcb-extract/src/types.rs
@@ -9,15 +9,12 @@ pub fn round_f64(v: f64, places: u32) -> f64 {
 }
 
 /// Wrapper that rounds f64 to 6 decimal places on serialization.
-/// Non-finite values (infinity, NaN) are serialized as 0.0 to avoid JSON nulls.
 fn serialize_f64_rounded<S: Serializer>(v: &f64, s: S) -> Result<S::Ok, S::Error> {
-    let val = if v.is_finite() { round_f64(*v, 6) } else { 0.0 };
-    s.serialize_f64(val)
+    s.serialize_f64(round_f64(*v, 6))
 }
 
 fn serialize_point<S: Serializer>(p: &[f64; 2], s: S) -> Result<S::Ok, S::Error> {
-    let clamp = |v: f64| if v.is_finite() { round_f64(v, 6) } else { 0.0 };
-    let rounded = [clamp(p[0]), clamp(p[1])];
+    let rounded = [round_f64(p[0], 6), round_f64(p[1], 6)];
     rounded.serialize(s)
 }
 
@@ -92,6 +89,53 @@ impl BBox {
         self.miny = self.miny.min(y);
         self.maxx = self.maxx.max(x);
         self.maxy = self.maxy.max(y);
+    }
+
+    /// Compute a bounding box from a slice of drawings.
+    /// Returns a default 100x100 box if no drawings contribute points.
+    pub fn from_drawings(edges: &[Drawing]) -> Self {
+        let mut bbox = Self::empty();
+        for edge in edges {
+            match edge {
+                Drawing::Segment { start, end, .. } | Drawing::Rect { start, end, .. } => {
+                    bbox.expand_point(start[0], start[1]);
+                    bbox.expand_point(end[0], end[1]);
+                }
+                Drawing::Circle { start, radius, .. } | Drawing::Arc { start, radius, .. } => {
+                    bbox.expand_point(start[0] - radius, start[1] - radius);
+                    bbox.expand_point(start[0] + radius, start[1] + radius);
+                }
+                Drawing::Curve {
+                    start,
+                    end,
+                    cpa,
+                    cpb,
+                    ..
+                } => {
+                    bbox.expand_point(start[0], start[1]);
+                    bbox.expand_point(end[0], end[1]);
+                    bbox.expand_point(cpa[0], cpa[1]);
+                    bbox.expand_point(cpb[0], cpb[1]);
+                }
+                Drawing::Polygon { polygons, .. } => {
+                    for poly in polygons {
+                        for pt in poly {
+                            bbox.expand_point(pt[0], pt[1]);
+                        }
+                    }
+                }
+            }
+        }
+        if !bbox.minx.is_finite() {
+            Self {
+                minx: 0.0,
+                miny: 0.0,
+                maxx: 100.0,
+                maxy: 100.0,
+            }
+        } else {
+            bbox
+        }
     }
 }
 

--- a/crates/pcb-extract/src/types.rs
+++ b/crates/pcb-extract/src/types.rs
@@ -9,12 +9,15 @@ pub fn round_f64(v: f64, places: u32) -> f64 {
 }
 
 /// Wrapper that rounds f64 to 6 decimal places on serialization.
+/// Non-finite values (infinity, NaN) are clamped to 0.0 to avoid JSON nulls.
 fn serialize_f64_rounded<S: Serializer>(v: &f64, s: S) -> Result<S::Ok, S::Error> {
-    s.serialize_f64(round_f64(*v, 6))
+    let val = if v.is_finite() { round_f64(*v, 6) } else { 0.0 };
+    s.serialize_f64(val)
 }
 
 fn serialize_point<S: Serializer>(p: &[f64; 2], s: S) -> Result<S::Ok, S::Error> {
-    let rounded = [round_f64(p[0], 6), round_f64(p[1], 6)];
+    let clamp = |v: f64| if v.is_finite() { round_f64(v, 6) } else { 0.0 };
+    let rounded = [clamp(p[0]), clamp(p[1])];
     rounded.serialize(s)
 }
 
@@ -39,7 +42,8 @@ fn serialize_opt_point<S: Serializer>(p: &Option<[f64; 2]>, s: S) -> Result<S::O
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PcbData {
-    pub edges_bbox: BBox,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub edges_bbox: Option<BBox>,
     pub edges: Vec<Drawing>,
     pub drawings: Drawings,
     pub footprints: Vec<Footprint>,
@@ -94,8 +98,8 @@ impl BBox {
     }
 
     /// Compute a bounding box from a slice of drawings.
-    /// Returns a default 100x100 box if no drawings contribute points.
-    pub fn from_drawings(edges: &[Drawing]) -> Self {
+    /// Returns `None` if no drawings contribute points.
+    pub fn from_drawings(edges: &[Drawing]) -> Option<Self> {
         let mut bbox = Self::empty();
         for edge in edges {
             match edge {
@@ -128,15 +132,10 @@ impl BBox {
                 }
             }
         }
-        if !bbox.minx.is_finite() {
-            Self {
-                minx: 0.0,
-                miny: 0.0,
-                maxx: 100.0,
-                maxy: 100.0,
-            }
+        if bbox.minx.is_finite() {
+            Some(bbox)
         } else {
-            bbox
+            None
         }
     }
 }

--- a/crates/pcb-extract/src/types.rs
+++ b/crates/pcb-extract/src/types.rs
@@ -9,12 +9,15 @@ pub fn round_f64(v: f64, places: u32) -> f64 {
 }
 
 /// Wrapper that rounds f64 to 6 decimal places on serialization.
+/// Non-finite values (infinity, NaN) are serialized as 0.0 to avoid JSON nulls.
 fn serialize_f64_rounded<S: Serializer>(v: &f64, s: S) -> Result<S::Ok, S::Error> {
-    s.serialize_f64(round_f64(*v, 6))
+    let val = if v.is_finite() { round_f64(*v, 6) } else { 0.0 };
+    s.serialize_f64(val)
 }
 
 fn serialize_point<S: Serializer>(p: &[f64; 2], s: S) -> Result<S::Ok, S::Error> {
-    let rounded = [round_f64(p[0], 6), round_f64(p[1], 6)];
+    let clamp = |v: f64| if v.is_finite() { round_f64(v, 6) } else { 0.0 };
+    let rounded = [clamp(p[0]), clamp(p[1])];
     rounded.serialize(s)
 }
 

--- a/crates/viewer/src/pcbdata.rs
+++ b/crates/viewer/src/pcbdata.rs
@@ -4,7 +4,8 @@ use std::collections::HashMap;
 #[derive(Debug, Clone, Deserialize)]
 #[allow(dead_code)]
 pub struct PcbData {
-    pub edges_bbox: BBox,
+    #[serde(default)]
+    pub edges_bbox: Option<BBox>,
     pub edges: Vec<Drawing>,
     pub drawings: Drawings,
     pub footprints: Vec<Footprint>,

--- a/crates/viewer/src/render.rs
+++ b/crates/viewer/src/render.rs
@@ -1196,7 +1196,14 @@ pub fn recalc_layer_scale(
     settings: &Settings,
 ) {
     let flip = layer.layer == "B";
-    let bbox = apply_rotation(&pcbdata.edges_bbox, flip, settings);
+    let default_bbox = BBox {
+        minx: 0.0,
+        miny: 0.0,
+        maxx: 100.0,
+        maxy: 100.0,
+    };
+    let edges_bbox = pcbdata.edges_bbox.as_ref().unwrap_or(&default_bbox);
+    let bbox = apply_rotation(edges_bbox, flip, settings);
     let mut scalefactor =
         0.98 * (width / (bbox.maxx - bbox.minx)).min(height / (bbox.maxy - bbox.miny));
     if scalefactor < 0.1 {


### PR DESCRIPTION
## Summary
- `BBox::empty()` uses `f64::INFINITY` which serde serializes as JSON `null`, crashing the viewer deserializer
- Clamp non-finite values (infinity, NaN) to `0.0` in `serialize_f64_rounded` and `serialize_point`
- **This is a bandaid** — the proper fix would be `Option<f64>` or rejecting empty parse results upstream

Fixes #49

## Test plan
- [x] All existing tests pass
- [x] `cargo clippy` clean