### PR TITLE
Re-parse stale boards on deploy

### DIFF
--- a/crates/pcb-extract/src/lib.rs
+++ b/crates/pcb-extract/src/lib.rs
@@ -127,7 +127,7 @@ pub fn extract_bytes(
         return Err(ExtractError::MacosResourceFork);
     }
 
-    match format {
+    let mut pcbdata = match format {
         PcbFormat::KiCad => parsers::kicad::parse(data, opts),
         PcbFormat::EasyEda => parsers::easyeda::parse(data, opts),
         PcbFormat::Eagle => parsers::eagle::parse(data, opts),
@@ -135,7 +135,9 @@ pub fn extract_bytes(
         PcbFormat::Gerber => parsers::gerber::parse(data, opts),
         PcbFormat::Gdsii => parsers::gdsii::parse(data, opts),
         PcbFormat::OdbPlusPlus => parsers::odbpp::parse(data, opts),
-    }
+    }?;
+    pcbdata.parser_version = Some(env!("CARGO_PKG_VERSION").to_string());
+    Ok(pcbdata)
 }
 
 #[cfg(test)]

--- a/crates/pcb-extract/src/parsers/altium/mod.rs
+++ b/crates/pcb-extract/src/parsers/altium/mod.rs
@@ -143,6 +143,7 @@ pub fn parse(data: &[u8], opts: &ExtractOptions) -> Result<PcbData, ExtractError
         footprints,
         metadata: extract_metadata(&board_records),
         bom,
+        parser_version: None,
         ibom_version: None,
         tracks: track_data,
         copper_pads: None,

--- a/crates/pcb-extract/src/parsers/eagle.rs
+++ b/crates/pcb-extract/src/parsers/eagle.rs
@@ -87,6 +87,7 @@ pub fn parse(data: &[u8], opts: &ExtractOptions) -> Result<PcbData, ExtractError
             date: String::new(),
         },
         bom,
+        parser_version: None,
         ibom_version: None,
         tracks,
         copper_pads: None,

--- a/crates/pcb-extract/src/parsers/eagle_binary.rs
+++ b/crates/pcb-extract/src/parsers/eagle_binary.rs
@@ -410,6 +410,7 @@ fn extract_board(
             date: String::new(),
         },
         bom,
+        parser_version: None,
         ibom_version: None,
         tracks,
         copper_pads: None,

--- a/crates/pcb-extract/src/parsers/easyeda.rs
+++ b/crates/pcb-extract/src/parsers/easyeda.rs
@@ -132,6 +132,7 @@ pub fn parse(data: &[u8], opts: &ExtractOptions) -> Result<PcbData, ExtractError
             date: String::new(),
         },
         bom,
+        parser_version: None,
         ibom_version: None,
         tracks,
         copper_pads: None,

--- a/crates/pcb-extract/src/parsers/gdsii.rs
+++ b/crates/pcb-extract/src/parsers/gdsii.rs
@@ -1550,6 +1550,7 @@ pub fn parse(data: &[u8], opts: &ExtractOptions) -> Result<PcbData, ExtractError
             date: String::new(),
         },
         bom,
+        parser_version: None,
         ibom_version: None,
         tracks,
         copper_pads: None,

--- a/crates/pcb-extract/src/parsers/gerber/mod.rs
+++ b/crates/pcb-extract/src/parsers/gerber/mod.rs
@@ -312,6 +312,7 @@ fn assemble_pcb_data(
             date: String::new(),
         },
         bom: None,
+        parser_version: None,
         ibom_version: None,
         tracks,
         copper_pads,

--- a/crates/pcb-extract/src/parsers/kicad.rs
+++ b/crates/pcb-extract/src/parsers/kicad.rs
@@ -115,6 +115,7 @@ pub fn parse(data: &[u8], opts: &ExtractOptions) -> Result<PcbData, ExtractError
         footprints,
         metadata,
         bom,
+        parser_version: None,
         ibom_version: None,
         tracks,
         copper_pads: None,

--- a/crates/pcb-extract/src/parsers/odbpp/mod.rs
+++ b/crates/pcb-extract/src/parsers/odbpp/mod.rs
@@ -488,6 +488,7 @@ pub fn parse(data: &[u8], opts: &ExtractOptions) -> Result<PcbData, ExtractError
             date: String::new(),
         },
         bom,
+        parser_version: None,
         ibom_version: None,
         tracks,
         copper_pads: copper_pads_out,

--- a/crates/pcb-extract/src/thumbnail.rs
+++ b/crates/pcb-extract/src/thumbnail.rs
@@ -409,6 +409,7 @@ mod tests {
                 company: String::new(),
                 date: String::new(),
             },
+            parser_version: None,
             bom: None,
             ibom_version: None,
             tracks: None,

--- a/crates/pcb-extract/src/types.rs
+++ b/crates/pcb-extract/src/types.rs
@@ -44,6 +44,8 @@ pub struct PcbData {
     pub drawings: Drawings,
     pub footprints: Vec<Footprint>,
     pub metadata: Metadata,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parser_version: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bom: Option<BomData>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -1,4 +1,5 @@
 mod github;
+mod reparse;
 mod routes;
 mod s3;
 
@@ -66,6 +67,12 @@ async fn main() {
         max_upload_bytes,
         parse_semaphore: Arc::new(Semaphore::new(max_concurrent_parses)),
     };
+
+    // Spawn background re-parse of stale boards
+    let reparse_s3 = state.s3.clone();
+    tokio::spawn(async move {
+        reparse::reparse_stale_boards(reparse_s3).await;
+    });
 
     let app = Router::new()
         .merge(routes::router(max_upload_bytes))

--- a/crates/server/src/reparse.rs
+++ b/crates/server/src/reparse.rs
@@ -1,0 +1,163 @@
+use crate::s3::S3Client;
+use pcb_extract::ExtractOptions;
+use std::path::Path;
+
+const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// A lightweight struct to check parser_version without deserializing full PcbData.
+#[derive(serde::Deserialize)]
+struct VersionProbe {
+    #[serde(default)]
+    parser_version: Option<String>,
+}
+
+/// Scan all stored boards and re-parse any with a stale or missing parser_version.
+/// Runs as a background task after server startup.
+pub async fn reparse_stale_boards(s3: S3Client) {
+    let bom_objects = match s3.list_objects("boms/").await {
+        Ok(objs) => objs,
+        Err(e) => {
+            tracing::warn!("Failed to list boms for reparse scan: {e}");
+            return;
+        }
+    };
+
+    let bom_ids: Vec<String> = bom_objects
+        .iter()
+        .filter_map(|o| {
+            o.key
+                .strip_prefix("boms/")
+                .and_then(|k| k.strip_suffix(".json"))
+                .filter(|k| !k.ends_with(".meta"))
+                .map(|k| k.to_string())
+        })
+        .collect();
+
+    tracing::info!(
+        "Reparse scan: checking {} boards against parser v{}",
+        bom_ids.len(),
+        CURRENT_VERSION
+    );
+
+    let mut reparsed = 0;
+    let mut skipped = 0;
+    let mut failed = 0;
+
+    for id in &bom_ids {
+        match check_and_reparse(&s3, id).await {
+            ReparseResult::Current => {}
+            ReparseResult::Reparsed => reparsed += 1,
+            ReparseResult::Skipped(reason) => {
+                tracing::debug!("Skipped reparse for {id}: {reason}");
+                skipped += 1;
+            }
+            ReparseResult::Failed(e) => {
+                tracing::warn!("Reparse failed for {id}: {e}");
+                failed += 1;
+            }
+        }
+
+        // Yield between boards to avoid starving request handling
+        tokio::task::yield_now().await;
+    }
+
+    if reparsed > 0 || failed > 0 {
+        tracing::info!(
+            "Reparse complete: {reparsed} updated, {skipped} skipped (no upload), {failed} failed"
+        );
+    }
+}
+
+enum ReparseResult {
+    Current,
+    Reparsed,
+    Skipped(String),
+    Failed(String),
+}
+
+async fn check_and_reparse(s3: &S3Client, id: &str) -> ReparseResult {
+    // Load just the parser_version field
+    let bom_key = format!("boms/{id}.json");
+    let json_bytes = match s3.get_object(&bom_key).await {
+        Ok(b) => b,
+        Err(_) => return ReparseResult::Failed("could not read bom json".into()),
+    };
+
+    let probe: VersionProbe = match serde_json::from_slice(&json_bytes) {
+        Ok(p) => p,
+        Err(_) => return ReparseResult::Failed("could not parse bom json".into()),
+    };
+
+    if probe.parser_version.as_deref() == Some(CURRENT_VERSION) {
+        return ReparseResult::Current;
+    }
+
+    let old_version = probe
+        .parser_version
+        .as_deref()
+        .unwrap_or("none")
+        .to_string();
+
+    // Find the original upload
+    let upload_objects = match s3.list_objects(&format!("uploads/{id}/")).await {
+        Ok(objs) => objs,
+        Err(_) => return ReparseResult::Skipped("could not list uploads".into()),
+    };
+
+    let upload_key = match upload_objects.first() {
+        Some(obj) => &obj.key,
+        None => return ReparseResult::Skipped("no original upload found".into()),
+    };
+
+    let filename = upload_key
+        .rsplit('/')
+        .next()
+        .unwrap_or("upload.bin")
+        .to_string();
+
+    let upload_data = match s3.get_object(upload_key).await {
+        Ok(d) => d,
+        Err(_) => return ReparseResult::Skipped("could not read original upload".into()),
+    };
+
+    // Detect format and re-parse
+    let path = Path::new(&filename);
+    let format = match pcb_extract::detect_format_with_content(path, &upload_data) {
+        Some(f) => f,
+        None => return ReparseResult::Skipped("could not detect format".into()),
+    };
+
+    let pcb_data = match tokio::task::spawn_blocking(move || {
+        let opts = ExtractOptions {
+            include_tracks: true,
+            include_nets: true,
+        };
+        pcb_extract::extract_bytes(&upload_data, format, &opts)
+    })
+    .await
+    {
+        Ok(Ok(data)) => data,
+        Ok(Err(e)) => return ReparseResult::Failed(format!("parse error: {e}")),
+        Err(_) => return ReparseResult::Failed("parse task panicked".into()),
+    };
+
+    // Store updated pcbdata
+    let pcbdata_json = match serde_json::to_vec(&pcb_data) {
+        Ok(j) => j,
+        Err(_) => return ReparseResult::Failed("json serialization failed".into()),
+    };
+
+    if let Err(e) = s3
+        .put_object(&bom_key, pcbdata_json, "application/json")
+        .await
+    {
+        return ReparseResult::Failed(format!("could not store updated bom: {e}"));
+    }
+
+    // Invalidate cached thumbnail
+    let thumb_key = format!("thumbnails/{id}.svg");
+    let _ = s3.delete_object(&thumb_key).await;
+
+    tracing::info!("Reparsed {id} ({filename}): v{old_version} -> v{CURRENT_VERSION}");
+    ReparseResult::Reparsed
+}

--- a/crates/server/src/s3.rs
+++ b/crates/server/src/s3.rs
@@ -166,6 +166,34 @@ impl S3Client {
         }
     }
 
+    pub async fn delete_object(&self, path: &str) -> Result<(), S3Error> {
+        match &self.backend {
+            StorageBackend::S3 {
+                client,
+                bucket,
+                prefix,
+            } => {
+                let key = s3_key(prefix, path);
+                client
+                    .delete_object()
+                    .bucket(bucket)
+                    .key(key)
+                    .send()
+                    .await
+                    .map_err(|e| S3Error(e.to_string()))?;
+                Ok(())
+            }
+            StorageBackend::Filesystem { root } => {
+                let file_path = root.join(path);
+                if file_path.exists() {
+                    std::fs::remove_file(&file_path)
+                        .map_err(|e| S3Error(format!("delete failed: {e}")))?;
+                }
+                Ok(())
+            }
+        }
+    }
+
     pub async fn get_object(&self, path: &str) -> Result<Vec<u8>, S3Error> {
         match &self.backend {
             StorageBackend::S3 {


### PR DESCRIPTION
## Summary
- Add `parser_version` field to `PcbData`, stamped automatically by `extract_bytes` from `CARGO_PKG_VERSION`
- On server startup, a background task scans all stored `boms/*.json`, checks `parser_version` against the running version
- Stale boards are re-parsed from original uploads (`uploads/{id}/*`) and the new pcbdata JSON + invalidated thumbnail are written back
- Boards without an original upload are skipped gracefully
- Added `S3Client::delete_object` for thumbnail cache invalidation

Closes #51