### PR TITLE
Remove GDSII support from website

### DIFF
--- a/crates/pcb-extract/src/lib.rs
+++ b/crates/pcb-extract/src/lib.rs
@@ -44,7 +44,6 @@ pub fn detect_format(path: &Path) -> Option<PcbFormat> {
         Some("json") => Some(PcbFormat::EasyEda),
         Some("brd") | Some("fbrd") => Some(PcbFormat::Eagle),
         Some("pcbdoc") => Some(PcbFormat::Altium),
-        Some("gds") | Some("gds2") => Some(PcbFormat::Gdsii),
         Some("tgz") => Some(PcbFormat::OdbPlusPlus),
         Some("zip") => Some(PcbFormat::Gerber),
         Some("gz") => {

--- a/crates/pcb-extract/src/main.rs
+++ b/crates/pcb-extract/src/main.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 #[derive(Parser)]
 #[command(name = "pcb-extract", about = "Extract PCB data to JSON")]
 struct Cli {
-    /// Input PCB file (.kicad_pcb, .json, .brd, .pcbdoc, .zip, .gds, .gds2, .tgz)
+    /// Input PCB file (.kicad_pcb, .json, .brd, .pcbdoc, .zip, .tgz)
     input: PathBuf,
 
     /// Output JSON file (stdout if not specified)

--- a/crates/server/src/reparse.rs
+++ b/crates/server/src/reparse.rs
@@ -4,11 +4,13 @@ use std::path::Path;
 
 const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-/// A lightweight struct to check parser_version without deserializing full PcbData.
+/// A lightweight struct to check parser_version/format without deserializing full PcbData.
 #[derive(serde::Deserialize)]
 struct VersionProbe {
     #[serde(default)]
     parser_version: Option<String>,
+    #[serde(default)]
+    format: Option<pcb_extract::PcbFormat>,
 }
 
 /// Scan all stored boards and re-parse any with a stale or missing parser_version.
@@ -87,6 +89,11 @@ async fn check_and_reparse(s3: &S3Client, id: &str) -> ReparseResult {
         Ok(p) => p,
         Err(_) => return ReparseResult::Failed("could not parse bom json".into()),
     };
+
+    // Skip formats no longer supported on the site
+    if probe.format == Some(pcb_extract::PcbFormat::Gdsii) {
+        return ReparseResult::Current;
+    }
 
     if probe.parser_version.as_deref() == Some(CURRENT_VERSION) {
         return ReparseResult::Current;

--- a/crates/server/static/index.html
+++ b/crates/server/static/index.html
@@ -187,7 +187,7 @@
     <div class="page-layout">
         <div class="main-column">
             <div class="upload-zone" id="dropzone">
-                <input type="file" id="fileInput" accept=".kicad_pcb,.json,.brd,.fbrd,.pcbdoc,.zip,.tgz,.tar.gz,.gds,.gds2">
+                <input type="file" id="fileInput" accept=".kicad_pcb,.json,.brd,.fbrd,.pcbdoc,.zip,.tgz,.tar.gz">
                 <p>Drop your PCB file here or click to browse</p>
                 <div class="formats">
                     <ul style="text-align: left; display: inline-block; margin: 0.5rem 0 0 0; padding-left: 1.5rem;">
@@ -195,7 +195,6 @@
                         <li>Altium (.PcbDoc)</li>
                         <li>Eagle (.brd, .fbrd)</li>
                         <li>EasyEDA (.json)</li>
-                        <li>GDSII (.gds, .gds2)</li>
                         <li>Gerber (.zip)</li>
                         <li>KiCad (.kicad_pcb)</li>
                         <li>ODB++ (.tgz, .zip, .tar.gz)</li>
@@ -285,7 +284,6 @@
             if (name.endsWith('.json')) return 'EasyEDA';
             if (name.endsWith('.brd') || name.endsWith('.fbrd')) return 'Eagle';
             if (name.endsWith('.pcbdoc')) return 'Altium';
-            if (name.endsWith('.gds') || name.endsWith('.gds2')) return 'GDSII';
             if (name.endsWith('.tgz') || name.endsWith('.tar.gz')) return 'ODB++';
             if (name.endsWith('.zip')) return 'Gerber/ODB++';
             return '';


### PR DESCRIPTION
## Summary
- Remove GDSII from upload file picker, format list, and JS detection
- Remove `.gds`/`.gds2` from server-side format detection (rejects uploads)
- Skip GDSII boards during startup reparse scan
- Parser code kept intact for CLI use

IC layout files produce output too large to serve usefully.