### PR TITLE
Move security audit to daily cron

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,19 +50,6 @@ jobs:
 
       - run: cargo test --workspace --exclude pastebom-viewer
 
-  audit:
-    name: Security Audit
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      checks: write
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: rustsec/audit-check@v2.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
   container:
     name: Container Build
     runs-on: ubuntu-latest

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,42 @@
+name: Security Audit
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit
+
+      - name: Run audit
+        id: audit
+        run: cargo audit 2>&1 | tee audit-output.txt
+        continue-on-error: true
+
+      - name: Open issue on failure
+        if: steps.audit.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BODY=$(cat audit-output.txt)
+          gh issue create \
+            --title "Security audit failed $(date +%Y-%m-%d)" \
+            --body "\`\`\`
+          ${BODY}
+          \`\`\`" \
+            --label "security"


### PR DESCRIPTION
## Summary
- Remove security audit from CI pipeline (no longer blocks PRs)
- New daily workflow at 3am UTC runs `cargo audit`
- Opens a GitHub issue with `security` label on failure
- Can also be triggered manually via `workflow_dispatch`
- Removed "Security Audit" from required branch protection checks