### PR TITLE
Pre-compress viewer assets at startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2015,12 +2015,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-range-header"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
-
-[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2720,8 +2714,11 @@ dependencies = [
  "aws-config",
  "aws-sdk-s3",
  "axum",
+ "brotli",
  "chrono",
+ "flate2",
  "hex",
+ "mime_guess",
  "pcb-extract",
  "reqwest",
  "serde",
@@ -3935,13 +3932,7 @@ dependencies = [
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
- "http-body-util",
- "http-range-header",
- "httpdate",
  "iri-string",
- "mime",
- "mime_guess",
- "percent-encoding",
  "pin-project-lite",
  "tokio",
  "tokio-util",

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -8,7 +8,7 @@ pcb-extract = { path = "../pcb-extract" }
 axum = { version = "0.8", features = ["multipart"] }
 tokio = { version = "1", features = ["full"] }
 tower = "0.5"
-tower-http = { version = "0.6", features = ["cors", "fs", "trace", "timeout", "compression-gzip", "compression-br"] }
+tower-http = { version = "0.6", features = ["cors", "trace", "timeout", "compression-gzip", "compression-br"] }
 aws-sdk-s3 = "1"
 aws-config = "1"
 uuid = { version = "1", features = ["v4"] }
@@ -20,3 +20,6 @@ chrono = "0.4.43"
 reqwest = { version = "0.13.2", features = ["json"] }
 sha2 = "0.11.0"
 hex = "0.4.3"
+brotli = "8.0.2"
+flate2 = "1.1.9"
+mime_guess = "2.0.5"

--- a/crates/server/src/compressed_assets.rs
+++ b/crates/server/src/compressed_assets.rs
@@ -1,0 +1,151 @@
+use axum::{
+    body::Body,
+    http::{header, HeaderMap, HeaderValue, StatusCode, Uri},
+    response::{IntoResponse, Response},
+};
+use std::collections::HashMap;
+use std::io::Write;
+use std::path::Path;
+use std::sync::OnceLock;
+
+struct CompressedAsset {
+    raw: Vec<u8>,
+    brotli: Vec<u8>,
+    gzip: Vec<u8>,
+    mime: String,
+}
+
+static CACHE: OnceLock<HashMap<String, CompressedAsset>> = OnceLock::new();
+
+/// Pre-compress all viewer assets from disk at startup.
+pub fn init_cache(viewer_dir: &Path) {
+    CACHE.get_or_init(|| {
+        let mut map = HashMap::new();
+        let mut total_raw = 0u64;
+        let mut total_br = 0u64;
+
+        let walker = match std::fs::read_dir(viewer_dir) {
+            Ok(w) => w,
+            Err(e) => {
+                tracing::warn!("Could not read viewer dir {}: {e}", viewer_dir.display());
+                return map;
+            }
+        };
+
+        for entry in walker.flatten() {
+            let path = entry.path();
+            if !path.is_file() {
+                continue;
+            }
+            let filename = match path.file_name().and_then(|f| f.to_str()) {
+                Some(f) => f.to_string(),
+                None => continue,
+            };
+            let raw = match std::fs::read(&path) {
+                Ok(d) => d,
+                Err(_) => continue,
+            };
+            let mime = mime_guess::from_path(&path)
+                .first_or_octet_stream()
+                .to_string();
+
+            let brotli_buf = {
+                let mut buf = Vec::new();
+                {
+                    let mut writer = brotli::CompressorWriter::new(&mut buf, 4096, 11, 22);
+                    writer.write_all(&raw).unwrap();
+                }
+                buf
+            };
+
+            let gzip_buf = {
+                let mut encoder =
+                    flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::best());
+                encoder.write_all(&raw).unwrap();
+                encoder.finish().unwrap()
+            };
+
+            total_raw += raw.len() as u64;
+            total_br += brotli_buf.len() as u64;
+
+            map.insert(
+                filename,
+                CompressedAsset {
+                    raw,
+                    brotli: brotli_buf,
+                    gzip: gzip_buf,
+                    mime,
+                },
+            );
+        }
+
+        if total_raw > 0 {
+            tracing::info!(
+                "Pre-compressed {} viewer assets: {:.1} MB raw -> {:.1} MB brotli ({:.0}% reduction)",
+                map.len(),
+                total_raw as f64 / 1_048_576.0,
+                total_br as f64 / 1_048_576.0,
+                (1.0 - total_br as f64 / total_raw as f64) * 100.0
+            );
+        }
+
+        map
+    });
+}
+
+/// Serve pre-compressed viewer assets. Falls back to index.html for SPA routing.
+pub async fn serve_viewer(uri: Uri, headers: HeaderMap) -> Response {
+    let path = uri.path().trim_start_matches("/viewer/");
+    let path = if path.is_empty() { "index.html" } else { path };
+
+    let cache = match CACHE.get() {
+        Some(c) => c,
+        None => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Asset cache not initialized",
+            )
+                .into_response()
+        }
+    };
+
+    let accept = headers
+        .get(header::ACCEPT_ENCODING)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+
+    let asset = cache.get(path).or_else(|| cache.get("index.html"));
+
+    match asset {
+        Some(asset) => {
+            let (body, encoding) = if accept.contains("br") {
+                (asset.brotli.as_slice(), Some("br"))
+            } else if accept.contains("gzip") {
+                (asset.gzip.as_slice(), Some("gzip"))
+            } else {
+                (asset.raw.as_slice(), None)
+            };
+
+            let cache_control = if path == "index.html" {
+                "no-cache"
+            } else {
+                "public, max-age=31536000, immutable"
+            };
+
+            let mut resp = Response::builder()
+                .status(StatusCode::OK)
+                .header(header::CONTENT_TYPE, &asset.mime)
+                .header(header::CACHE_CONTROL, cache_control)
+                .body(Body::from(body.to_vec()))
+                .unwrap();
+
+            if let Some(enc) = encoding {
+                resp.headers_mut()
+                    .insert(header::CONTENT_ENCODING, HeaderValue::from_static(enc));
+            }
+
+            resp
+        }
+        None => (StatusCode::NOT_FOUND, "Asset not found").into_response(),
+    }
+}

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -1,9 +1,11 @@
+mod compressed_assets;
 mod github;
 mod reparse;
 mod routes;
 mod s3;
 
 use axum::http::StatusCode;
+use axum::routing::get;
 use axum::Router;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -11,7 +13,6 @@ use std::time::Duration;
 use tokio::sync::{RwLock, Semaphore};
 use tower_http::compression::CompressionLayer;
 use tower_http::cors::CorsLayer;
-use tower_http::services::ServeDir;
 use tower_http::timeout::TimeoutLayer;
 use tower_http::trace::TraceLayer;
 
@@ -69,6 +70,9 @@ async fn main() {
         parse_semaphore: Arc::new(Semaphore::new(max_concurrent_parses)),
     };
 
+    // Pre-compress viewer assets at startup
+    compressed_assets::init_cache(&viewer_dir);
+
     // Spawn background re-parse of stale boards
     let reparse_s3 = state.s3.clone();
     tokio::spawn(async move {
@@ -77,7 +81,8 @@ async fn main() {
 
     let app = Router::new()
         .merge(routes::router(max_upload_bytes))
-        .nest_service("/viewer", ServeDir::new(&viewer_dir))
+        .route("/viewer/*path", get(compressed_assets::serve_viewer))
+        .route("/viewer/", get(compressed_assets::serve_viewer))
         .layer(CompressionLayer::new())
         .layer(CorsLayer::permissive())
         .layer(TimeoutLayer::with_status_code(


### PR DESCRIPTION
## Summary
- Pre-compress all viewer assets (WASM, JS, CSS) at startup with brotli (q11) and gzip
- Serve pre-compressed variants based on Accept-Encoding header
- Hashed filenames get `immutable` cache headers, index.html gets `no-cache`
- Replaces `ServeDir` with in-memory asset serving (following agent-portal's approach)
- `CompressionLayer` kept for dynamic responses (JSON API, uploads)