### PR TITLE
Render inner-layer zones in the viewer

### DIFF
--- a/crates/viewer/src/main.rs
+++ b/crates/viewer/src/main.rs
@@ -820,11 +820,17 @@ fn app() -> Html {
 
     let has_nets = data.nets.is_some();
     let has_tracks = data.tracks.is_some();
-    let inner_layer_names: Vec<String> = data
-        .tracks
-        .as_ref()
-        .map(|t| t.inner_layer_names().into_iter().cloned().collect())
-        .unwrap_or_default();
+    let inner_layer_names: Vec<String> = {
+        use std::collections::BTreeSet;
+        let mut names: BTreeSet<String> = BTreeSet::new();
+        if let Some(ref t) = data.tracks {
+            names.extend(t.inner_layer_names().into_iter().cloned());
+        }
+        if let Some(ref z) = data.zones {
+            names.extend(z.inner_layer_names().into_iter().cloned());
+        }
+        names.into_iter().collect()
+    };
 
     let bom_entries = get_bom_entries(&data, &settings, &filter);
 

--- a/crates/viewer/src/render.rs
+++ b/crates/viewer/src/render.rs
@@ -1074,6 +1074,26 @@ pub fn draw_nets(
             highlighted_net,
             zone_cache,
         );
+        // Dimmed inner-layer zones, gated by the same hidden_layers toggle as inner tracks.
+        if let Some(ref zones) = pcbdata.zones {
+            let ctx = get_ctx(canvas);
+            ctx.save();
+            ctx.set_global_alpha(0.25);
+            for name in zones.inner_layer_names() {
+                if !settings.hidden_layers.contains(name.as_str()) {
+                    draw_zones(
+                        canvas,
+                        name,
+                        zone_color,
+                        highlight,
+                        pcbdata,
+                        highlighted_net,
+                        zone_cache,
+                    );
+                }
+            }
+            ctx.restore();
+        }
     }
     if settings.render_tracks {
         draw_tracks(


### PR DESCRIPTION
## Summary
- `draw_nets` now loops `zones.inner` after the F/B pass, dimmed to 25% global alpha and gated on `settings.hidden_layers` — a direct mirror of the existing inner-tracks loop, so copper pours on inner layers behave the same way as inner tracks do today (dim, toggleable from the layer panel).
- `main.rs` unions `tracks.inner_layer_names()` and `zones.inner_layer_names()` so boards with inner zones but no inner tracks still register their layers in the toggle UI.

Before this, `draw_zones` only rendered F/B and inner zones were silently dropped even though KiCad, ODB++, and GDSII parsers already populate `zones.inner`.

## Why not "silkscreen in all" too?
Silkscreen is physically a surface-only process — it's screen-printed on the outer surfaces of a PCB and can't exist on sandwiched inner layers. The data model permits `drawings.silkscreen.inner` because `LayerData<T>` is generic, but no parser emits inner silkscreen and no real board has it, so there is nothing to render. If you meant something different (e.g., showing both F and B silkscreen simultaneously regardless of flip), happy to do that in a follow-up — just let me know.

## Test plan
- [x] `cargo check --target wasm32-unknown-unknown -p pastebom-viewer` — clean
- [x] `cargo clippy --target wasm32-unknown-unknown -p pastebom-viewer --bins` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test --workspace --lib` — 207 passed
- [ ] Visual verification in preview deploy with a multi-layer KiCad board