### PR TITLE
Fix KiCad arc direction by honouring the mid point

### DIFF
--- a/crates/pcb-extract/src/parsers/kicad.rs
+++ b/crates/pcb-extract/src/parsers/kicad.rs
@@ -1133,13 +1133,16 @@ fn rotate_and_translate(lx: f64, ly: f64, tx: f64, ty: f64, angle_deg: f64) -> (
     (rx + tx, ry + ty)
 }
 
-/// Compute arc center, radius, start angle, end angle from three points.
+/// Compute arc center, radius, start angle, end angle from three points
+/// (start, mid, end). The returned (start, end) angles are ordered so that the
+/// HTML canvas default sweep direction (increasing angle, i.e. clockwise in the
+/// Y-down canvas) traces the arc through the mid point — swapped when the
+/// natural increasing-angle sweep would go the wrong way around the circle.
 fn arc_from_three_points(
     p1: [f64; 2],
     p2: [f64; 2],
     p3: [f64; 2],
 ) -> Option<([f64; 2], f64, f64, f64)> {
-    // Find circumcenter of three points
     let ax = p1[0];
     let ay = p1[1];
     let bx = p2[0];
@@ -1163,7 +1166,122 @@ fn arc_from_three_points(
 
     let radius = ((ax - ux).powi(2) + (ay - uy).powi(2)).sqrt();
     let start_angle = (ay - uy).atan2(ax - ux) * 180.0 / PI;
+    let mid_angle = (by - uy).atan2(bx - ux) * 180.0 / PI;
     let end_angle = (cy - uy).atan2(cx - ux) * 180.0 / PI;
 
-    Some(([ux, uy], radius, start_angle, end_angle))
+    // Forward offsets (in [0, 360)) measure how far we travel in the
+    // increasing-angle direction starting from `start_angle`. If the mid lies
+    // *after* the end on that path, the natural sweep skips the mid and we
+    // need to swap start/end so the canvas draws the arc the other way around.
+    let forward = |a: f64| -> f64 {
+        let v = (a - start_angle) % 360.0;
+        if v < 0.0 {
+            v + 360.0
+        } else {
+            v
+        }
+    };
+    let mid_offset = forward(mid_angle);
+    let end_offset = forward(end_angle);
+    if mid_offset > end_offset {
+        Some(([ux, uy], radius, end_angle, start_angle))
+    } else {
+        Some(([ux, uy], radius, start_angle, end_angle))
+    }
+}
+
+#[cfg(test)]
+mod arc_tests {
+    use super::*;
+
+    /// In Y-down canvas, the default `arc(..., false)` sweep covers angles in
+    /// the increasing direction (with wrap to keep `end >= start`). This helper
+    /// returns that traced sweep magnitude in degrees.
+    fn forward_sweep(start: f64, end: f64) -> f64 {
+        let s = (end - start) % 360.0;
+        if s < 0.0 {
+            s + 360.0
+        } else {
+            s
+        }
+    }
+
+    fn pt_on_circle(cx: f64, cy: f64, r: f64, deg: f64) -> [f64; 2] {
+        let rad = deg * std::f64::consts::PI / 180.0;
+        [cx + r * rad.cos(), cy + r * rad.sin()]
+    }
+
+    #[test]
+    fn short_arc_through_mid_drives_direction() {
+        // Circle centered at origin, radius 1, going from -135° through -180°
+        // (= +180°) to +180° — a tight 45° arc the "short way" around.
+        let c = [0.0, 0.0];
+        let r = 1.0;
+        let start = pt_on_circle(c[0], c[1], r, -135.0);
+        let mid = pt_on_circle(c[0], c[1], r, -157.5);
+        let end = pt_on_circle(c[0], c[1], r, 180.0);
+        let (_, _, sa, ea) = arc_from_three_points(start, mid, end).unwrap();
+        // Canvas-default sweep should be the small one (~45°), not 315°.
+        assert!(
+            (forward_sweep(sa, ea) - 45.0).abs() < 0.01,
+            "sweep was {}°, expected 45°",
+            forward_sweep(sa, ea)
+        );
+    }
+
+    #[test]
+    fn long_arc_through_mid_keeps_long_sweep() {
+        // Same endpoints as above but mid pushed to the other side — the
+        // canvas should now sweep the long way (~315°) through the mid.
+        let c = [0.0, 0.0];
+        let r = 1.0;
+        let start = pt_on_circle(c[0], c[1], r, -135.0);
+        let mid = pt_on_circle(c[0], c[1], r, 0.0);
+        let end = pt_on_circle(c[0], c[1], r, 180.0);
+        let (_, _, sa, ea) = arc_from_three_points(start, mid, end).unwrap();
+        assert!(
+            (forward_sweep(sa, ea) - 315.0).abs() < 0.01,
+            "sweep was {}°, expected 315°",
+            forward_sweep(sa, ea)
+        );
+    }
+
+    #[test]
+    fn quarter_arc_first_quadrant() {
+        // 0° → 90° via 45° — the natural forward sweep direction is correct.
+        let c = [10.0, 5.0];
+        let r = 2.0;
+        let start = pt_on_circle(c[0], c[1], r, 0.0);
+        let mid = pt_on_circle(c[0], c[1], r, 45.0);
+        let end = pt_on_circle(c[0], c[1], r, 90.0);
+        let (center, radius, sa, ea) = arc_from_three_points(start, mid, end).unwrap();
+        assert!((center[0] - c[0]).abs() < 1e-6);
+        assert!((center[1] - c[1]).abs() < 1e-6);
+        assert!((radius - r).abs() < 1e-6);
+        assert!((forward_sweep(sa, ea) - 90.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn collinear_returns_none() {
+        let p1 = [0.0, 0.0];
+        let p2 = [1.0, 0.0];
+        let p3 = [2.0, 0.0];
+        assert!(arc_from_three_points(p1, p2, p3).is_none());
+    }
+
+    #[test]
+    fn mid_through_zero_crossing() {
+        // 350° → 0° → 10° — a 20° arc that wraps across the 0/360 seam.
+        let c = [0.0, 0.0];
+        let r = 1.0;
+        let start = pt_on_circle(c[0], c[1], r, 350.0);
+        let mid = pt_on_circle(c[0], c[1], r, 0.0);
+        let end = pt_on_circle(c[0], c[1], r, 10.0);
+        let (_, _, sa, ea) = arc_from_three_points(start, mid, end).unwrap();
+        assert!(
+            (forward_sweep(sa, ea) - 20.0).abs() < 0.01,
+            "sweep was {}°, expected 20°",
+            forward_sweep(sa, ea)
+        );
+    }
 }

--- a/crates/pcb-extract/src/thumbnail.rs
+++ b/crates/pcb-extract/src/thumbnail.rs
@@ -218,15 +218,19 @@ fn render_arc(
     let x2 = center[0] + radius * e_rad.cos();
     let y2 = center[1] + radius * e_rad.sin();
 
-    let mut sweep = end_deg - start_deg;
-    while sweep < -180.0 {
-        sweep += 360.0;
-    }
-    while sweep > 180.0 {
-        sweep -= 360.0;
-    }
-    let large = if sweep.abs() > 180.0 { 1 } else { 0 };
-    let sweep_flag = if sweep > 0.0 { 1 } else { 0 };
+    // Match the viewer's canvas-default sweep: forward (increasing angle) from
+    // start to end, normalized into [0, 360). large_arc_flag is set when that
+    // sweep exceeds a half-turn so SVG traces the same path the canvas does.
+    let forward_sweep = {
+        let s = (end_deg - start_deg) % 360.0;
+        if s < 0.0 {
+            s + 360.0
+        } else {
+            s
+        }
+    };
+    let large = if forward_sweep > 180.0 { 1 } else { 0 };
+    let sweep_flag = 1;
 
     let sw = if width < 0.1 { 0.1 } else { width };
     write!(
@@ -591,6 +595,37 @@ mod tests {
         let svg = render_svg(&data);
         assert!(svg.contains("<path d=\"M"));
         assert!(svg.contains("A5.0000"));
+    }
+
+    #[test]
+    fn test_short_arc_uses_small_arc_flag() {
+        // 0° → 90° forward sweep is 90°, so SVG large_arc_flag must be 0
+        // and sweep_flag is fixed at 1 (matches viewer's canvas-default sweep).
+        let mut data = minimal_pcbdata();
+        data.edges.push(Drawing::Arc {
+            start: [0.0, 0.0],
+            radius: 5.0,
+            startangle: 0.0,
+            endangle: 90.0,
+            width: 0.2,
+        });
+        let svg = render_svg(&data);
+        assert!(svg.contains("0 1 "), "expected large=0 sweep=1 in: {svg}");
+    }
+
+    #[test]
+    fn test_long_arc_sets_large_arc_flag() {
+        // start=180°, end=90° wraps forward through 360° → 90°, sweep=270°.
+        let mut data = minimal_pcbdata();
+        data.edges.push(Drawing::Arc {
+            start: [0.0, 0.0],
+            radius: 5.0,
+            startangle: 180.0,
+            endangle: 90.0,
+            width: 0.2,
+        });
+        let svg = render_svg(&data);
+        assert!(svg.contains("1 1 "), "expected large=1 sweep=1 in: {svg}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `arc_from_three_points` (`crates/pcb-extract/src/parsers/kicad.rs`) was computing the circumcenter from (start, mid, end) but then deriving `start_angle`/`end_angle` only from start and end. The mid — the only thing that says which way around the circle the arc goes — was silently dropped, so the emitted sweep was right-by-luck depending on `atan2` signs.
- The function now compares the forward (increasing-angle) offset of the mid against the end on the circle. If the canvas-default sweep (clockwise in the Y-down canvas) would skip the mid, it swaps the emitted start/end so the renderer traces the path the user actually drew.
- `thumbnail::render_arc` had a related-but-different bug: it normalized any sweep to `[-180, 180]`, so it could never produce a >180° arc no matter what the schema said. It now derives `large_arc_flag` from the same forward-sweep convention as the viewer and pins `sweep_flag` to 1, so the SVG thumbnail and canvas viewer trace the same shape.

## Repro
Reported on https://pastebom.com/b/446da576-910d-4ef7-a215-bd4cd75ffb56 (a KeyChainFlashLight KiCad board). Diagnostic: `tracks.F[10]` had `startangle=-135°, endangle=180°` → forward sweep of **315°** where the source intended a 45° arc. Footprint `D1` had two arcs on the same circle, same center, that disagreed on direction (one CCW, one CW) — clear sign extraction was non-deterministic on direction.

## Migration note
Stored boards parsed before this commit keep their old (buggy) angles in cached JSON until the parser version bumps and `reparse_stale_boards` regenerates them. Deliberately not bumping the workspace version in this PR — leaving that for whoever cuts the next release. New uploads use the corrected convention immediately.

## Test plan
- [x] 5 new tests in `parsers::kicad::arc_tests` cover: short-arc-via-mid drives the swap, long-arc-via-mid keeps the long sweep, simple quarter arc, collinear input returns None, mid across the 0°/360° seam.
- [x] 2 new thumbnail tests assert SVG `large_arc_flag` is 0 for a 90° arc and 1 for a 270° arc.
- [x] `cargo test -p pcb-extract --lib` — 223 pass.
- [x] `cargo fmt --check`, `cargo clippy` — clean (no new warnings).
- [ ] Visual confirmation on a redeploy with the keychain board re-uploaded — easiest to verify by re-uploading the source `.kicad_pcb` after this lands.