### PR TITLE
Bump version to 1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 1.9.0
+
+- Fix KiCad arc direction by honouring the (start, mid, end) point convention; thumbnail and viewer now trace the same sweep
+- Extract copper-pour zones from Eagle XML (`<polygon>` under `<signal>`)
+- Render inner-layer copper zones in the viewer with the existing layer toggle
+- Reject OpenBoardView ASCII `.brd` files with a clear error instead of a misleading XML parse failure
+- Support Eagle binary `.brd` format (pre-6.0)
+- Pre-compress viewer assets at startup and serve gzip/brotli responses
+- Re-parse stale boards on deploy when `parser_version` is older than the current build (so this release reprocesses previously-stored arcs and zones)
+- Reconstruct recent uploads list from S3 when `recent.json` is missing
+- Add SVG thumbnail endpoint with S3 cache
+- Mobile sidebars and per-layer toggles; trackpad two-finger scroll pans instead of zooming
+- Match viewer dark theme to landing page; brighten pull-tab handles in dark mode
+- Reject macOS resource fork files and malformed GDSII archives early; ZIP/tar bomb detection for archive uploads
+- Filter GDSII boards from the recent uploads list and remove GDSII from the supported-format display
+- Prevent large uploads from locking up the server (parse semaphore)
+- Configurable max upload size via `MAX_UPLOAD_SIZE` env var
+- Clamp non-finite f64 values to 0.0 during serialization
+
 ## 1.8.0
 
 - Add ODB++ file format support (.tgz and .zip archives)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2709,7 +2709,7 @@ dependencies = [
 
 [[package]]
 name = "pastebom-server"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "aws-config",
  "aws-sdk-s3",
@@ -2734,7 +2734,7 @@ dependencies = [
 
 [[package]]
 name = "pastebom-viewer"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "gloo 0.11.0",
  "js-sys",
@@ -2760,7 +2760,7 @@ dependencies = [
 
 [[package]]
 name = "pcb-extract"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "approx",
  "cfb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,4 @@ members = ["crates/pcb-extract", "crates/server", "crates/viewer"]
 resolver = "2"
 
 [workspace.package]
-version = "1.8.0"
+version = "1.9.0"


### PR DESCRIPTION
## Summary
Cuts release 1.9.0. The headline reason for the bump is that the KiCad arc direction fix (#77) changes the meaning of `(startangle, endangle)` in the cached PCB JSON — bumping `parser_version` triggers `reparse_stale_boards` on next deploy so already-uploaded boards get regenerated with the corrected angles.

## CHANGELOG.md additions
Covers user-visible changes since 1.8.0:

- Fix KiCad arc direction by honouring the (start, mid, end) point convention; thumbnail and viewer now trace the same sweep
- Extract copper-pour zones from Eagle XML
- Render inner-layer copper zones in the viewer with the existing layer toggle
- Reject OpenBoardView ASCII `.brd` files with a clear error
- Support Eagle binary `.brd` format (pre-6.0)
- Pre-compress viewer assets and serve gzip/brotli responses
- Re-parse stale boards on deploy
- Reconstruct recent uploads list from S3 when `recent.json` is missing
- Add SVG thumbnail endpoint with S3 cache
- Mobile sidebars + per-layer toggles; trackpad two-finger scroll pans instead of zooming
- Match viewer dark theme to landing page; brighten pull-tab handles in dark mode
- Reject macOS resource fork files and malformed GDSII archives early; ZIP/tar bomb detection
- Filter GDSII from the recent uploads list and supported-format display
- Prevent large uploads from locking up the server
- Configurable max upload size via `MAX_UPLOAD_SIZE`
- Clamp non-finite f64 values to 0.0 during serialization

## Test plan
- [x] `cargo build --workspace` — clean (server + viewer pick up 1.9.0)
- [x] `cargo test --workspace --lib` — 223 pass
- [x] `Cargo.lock` regenerated with new server/viewer versions