### PR TITLE
Ignore .claude/ agent state directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 *.swp
 *.swo
 
+# Claude Code agent state
+.claude/
+
 # Local development
 .env
 data/


### PR DESCRIPTION
Adds `.claude/` to `.gitignore` so local Claude Code agent state (worktrees, settings) isn't accidentally committed.

Closes #222