### PR TITLE
Make clippy gate fail on warnings and lint viewer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
+          targets: wasm32-unknown-unknown
 
       - uses: Swatinem/rust-cache@v2
 
-      - run: cargo clippy --workspace --exclude pastebom-viewer -- -W clippy::all
+      - run: cargo clippy --workspace --exclude pastebom-viewer -- -D warnings
+
+      - run: cargo clippy -p pastebom-viewer --target wasm32-unknown-unknown -- -D warnings
 
   test:
     name: Tests

--- a/crates/pcb-extract/src/bom.rs
+++ b/crates/pcb-extract/src/bom.rs
@@ -116,7 +116,7 @@ fn group_components(
     groups
         .into_iter()
         .map(|(_, _, mut refs)| {
-            refs.sort_by(|a, b| natural_sort_key(&a.0).cmp(&natural_sort_key(&b.0)));
+            refs.sort_by_key(|r| natural_sort_key(&r.0));
             refs
         })
         .collect()

--- a/crates/pcb-extract/src/parsers/easyeda.rs
+++ b/crates/pcb-extract/src/parsers/easyeda.rs
@@ -379,26 +379,24 @@ fn parse_easyeda_component(
                     }
                 }
             }
-            "CIRCLE" => {
-                if parts.len() >= 6 {
-                    let cx = mil_to_mm(parts[1].parse::<f64>().unwrap_or(0.0) - origin_x);
-                    let cy = mil_to_mm(parts[2].parse::<f64>().unwrap_or(0.0) - origin_y);
-                    let radius = mil_to_mm(parts[3].parse::<f64>().unwrap_or(0.0));
-                    let width = mil_to_mm(parts[4].parse::<f64>().unwrap_or(0.0));
-                    let layer_id: u32 = parts[5].parse().unwrap_or(0);
-                    let side = easyeda_layer_to_side(layer_id);
-                    bbox.expand_point(cx - radius, cy - radius);
-                    bbox.expand_point(cx + radius, cy + radius);
-                    drawings.push(FootprintDrawing {
-                        layer: side.to_string(),
-                        drawing: FootprintDrawingItem::Shape(Drawing::Circle {
-                            start: [cx, cy],
-                            radius,
-                            width,
-                            filled: None,
-                        }),
-                    });
-                }
+            "CIRCLE" if parts.len() >= 6 => {
+                let cx = mil_to_mm(parts[1].parse::<f64>().unwrap_or(0.0) - origin_x);
+                let cy = mil_to_mm(parts[2].parse::<f64>().unwrap_or(0.0) - origin_y);
+                let radius = mil_to_mm(parts[3].parse::<f64>().unwrap_or(0.0));
+                let width = mil_to_mm(parts[4].parse::<f64>().unwrap_or(0.0));
+                let layer_id: u32 = parts[5].parse().unwrap_or(0);
+                let side = easyeda_layer_to_side(layer_id);
+                bbox.expand_point(cx - radius, cy - radius);
+                bbox.expand_point(cx + radius, cy + radius);
+                drawings.push(FootprintDrawing {
+                    layer: side.to_string(),
+                    drawing: FootprintDrawingItem::Shape(Drawing::Circle {
+                        start: [cx, cy],
+                        radius,
+                        width,
+                        filled: None,
+                    }),
+                });
             }
             _ => {}
         }

--- a/crates/pcb-extract/src/parsers/gerber/mod.rs
+++ b/crates/pcb-extract/src/parsers/gerber/mod.rs
@@ -224,16 +224,14 @@ fn assemble_pcb_data(
                     }
                 }
             }
-            GerberLayerType::CopperInner(ref name) => {
-                if opts.include_tracks {
-                    let inner_tracks = tracks_inner.entry(name.clone()).or_default();
-                    let inner_pads = pads_inner.entry(name.clone()).or_default();
-                    for d in &output.drawings {
-                        if let Some(track) = drawing_to_track(d) {
-                            inner_tracks.push(track);
-                        } else {
-                            inner_pads.push(d.clone());
-                        }
+            GerberLayerType::CopperInner(ref name) if opts.include_tracks => {
+                let inner_tracks = tracks_inner.entry(name.clone()).or_default();
+                let inner_pads = pads_inner.entry(name.clone()).or_default();
+                for d in &output.drawings {
+                    if let Some(track) = drawing_to_track(d) {
+                        inner_tracks.push(track);
+                    } else {
+                        inner_pads.push(d.clone());
                     }
                 }
             }

--- a/crates/server/src/routes.rs
+++ b/crates/server/src/routes.rs
@@ -108,7 +108,7 @@ async fn reconstruct_recent(s3: &crate::s3::S3Client) -> Vec<RecentEntry> {
         .into_iter()
         .filter(|o| o.key.ends_with(".meta.json"))
         .collect();
-    meta_objects.sort_by(|a, b| b.last_modified.cmp(&a.last_modified));
+    meta_objects.sort_by_key(|o| std::cmp::Reverse(o.last_modified));
     meta_objects.truncate(MAX_RECENT);
 
     let mut entries = Vec::new();


### PR DESCRIPTION
The clippy job ran with `-W clippy::all`, which exits 0 on warnings, so lint regressions never failed CI. This switches it to `-D warnings` and adds the previously-unchecked `pastebom-viewer` crate (linted on the `wasm32-unknown-unknown` target).

Tightening the gate surfaced a few pre-existing lints, fixed here:
- `sort_by` → `sort_by_key` in `routes.rs` and `bom.rs`
- collapsed nested `if` into match guards in the EasyEDA and Gerber parsers

All 223 pcb-extract tests still pass; both clippy invocations are clean locally.

Closes #220