### PR TITLE
Fix viewer low-severity rendering and interaction bugs

### DIFF
--- a/crates/viewer/src/main.rs
+++ b/crates/viewer/src/main.rs
@@ -499,10 +499,10 @@ fn app() -> Html {
                             let bom_entries =
                                 get_bom_entries(data, &settings, &filter.to_lowercase());
                             let row_id = fps.first().and_then(|&fp_idx| {
-                                bom_entries.iter().enumerate().find_map(|(i, entry)| {
+                                bom_entries.iter().find_map(|entry| {
                                     if let BomEntry::Component { refs, .. } = entry {
                                         if refs.iter().any(|r| r.1 == fp_idx) {
-                                            Some(format!("bomrow{}", i + 1))
+                                            Some(bom_row_id(entry))
                                         } else {
                                             None
                                         }
@@ -938,7 +938,7 @@ fn app() -> Html {
                             </thead>
                             <tbody id="bombody">
                                 {for bom_entries.iter().enumerate().map(|(idx, entry)| {
-                                    let row_id = format!("bomrow{}", idx + 1);
+                                    let row_id = bom_row_id(entry);
                                     let is_highlighted = (*current_row).as_deref() == Some(row_id.as_str());
 
                                     let handler = {
@@ -1179,6 +1179,24 @@ enum BomEntry {
     Net {
         name: String,
     },
+}
+
+/// Stable DOM id for a BOM row, derived from the entry's identity rather than
+/// its position in the (filterable) list, so highlighting survives search edits.
+fn bom_row_id(entry: &BomEntry) -> String {
+    match entry {
+        BomEntry::Component { refs, .. } => {
+            let mut idxs: Vec<usize> = refs.iter().map(|r| r.1).collect();
+            idxs.sort_unstable();
+            let key = idxs
+                .iter()
+                .map(|i| i.to_string())
+                .collect::<Vec<_>>()
+                .join("_");
+            format!("bomrow-c{key}")
+        }
+        BomEntry::Net { name } => format!("bomrow-n{name}"),
+    }
 }
 
 fn get_bom_entries(data: &PcbData, settings: &Settings, filter: &str) -> Vec<BomEntry> {

--- a/crates/viewer/src/render.rs
+++ b/crates/viewer/src/render.rs
@@ -1226,7 +1226,7 @@ pub fn recalc_layer_scale(
     let bbox = apply_rotation(edges_bbox, flip, settings);
     let mut scalefactor =
         0.98 * (width / (bbox.maxx - bbox.minx)).min(height / (bbox.maxy - bbox.miny));
-    if scalefactor < 0.1 {
+    if !scalefactor.is_finite() || scalefactor < 0.1 {
         scalefactor = 1.0;
     }
     layer.transform.s = scalefactor;
@@ -1344,13 +1344,15 @@ pub fn draw_background(
             ctx.save();
             ctx.set_global_alpha(0.25);
             for name in copper_pads.inner_layer_names() {
-                draw_copper_pads(
-                    &layer.bg,
-                    name,
-                    primary_color,
-                    layer.transform.s * layer.transform.zoom,
-                    pcbdata,
-                );
+                if !settings.hidden_layers.contains(name.as_str()) {
+                    draw_copper_pads(
+                        &layer.bg,
+                        name,
+                        primary_color,
+                        layer.transform.s * layer.transform.zoom,
+                        pcbdata,
+                    );
+                }
             }
             ctx.restore();
         }
@@ -1588,16 +1590,31 @@ fn track_hit_scan(tracks: &[Track], x: f64, y: f64) -> Option<String> {
             }
             Track::Arc {
                 center,
+                startangle,
+                endangle,
                 radius,
                 width,
                 net,
-                ..
             } => {
                 let dx = x - center[0];
                 let dy = y - center[1];
                 let dist = (dx * dx + dy * dy).sqrt();
                 if (dist - radius).abs() <= width / 2.0 {
-                    return net.clone();
+                    // Only hit when the click also falls within the arc's angular
+                    // sweep (canvas default, increasing-angle direction).
+                    let start = deg2rad(*startangle);
+                    let end = deg2rad(*endangle);
+                    let two_pi = std::f64::consts::TAU;
+                    let sweep = (end - start).rem_euclid(two_pi);
+                    let offset = (dy.atan2(dx) - start).rem_euclid(two_pi);
+                    let tol = if *radius > 0.0 {
+                        width / 2.0 / radius
+                    } else {
+                        0.0
+                    };
+                    if offset <= sweep + tol || offset >= two_pi - tol {
+                        return net.clone();
+                    }
                 }
             }
         }


### PR DESCRIPTION
Four independent low-severity viewer fixes:

- **#216** — arc track hit-testing checked distance to the full circle but ignored `startangle`/`endangle`, so clicks on the opposite side of the circle selected the arc's net. Now checks the click falls within the arc's angular sweep.
- **#217** — BOM row DOM ids were positional (`bomrow{idx+1}`) over the *filtered* list, so editing the search re-numbered rows and the highlight/scroll landed on the wrong row. Ids now derive from entry identity (footprint indices / net name).
- **#218** — inner copper pads ignored `hidden_layers`, unlike inner tracks/zones; toggling an inner layer off now hides its pads too.
- **#219** — a degenerate (point-like) board bbox produced a non-finite `scalefactor`; now guarded.

Viewer clippy (`-D warnings`, wasm target) and build are clean locally.

Closes #216, #217, #218, #219