### PR TITLE
Fix parser panics on malformed EasyEDA and Excellon input

### DIFF
--- a/crates/pcb-extract/src/parsers/easyeda.rs
+++ b/crates/pcb-extract/src/parsers/easyeda.rs
@@ -198,7 +198,7 @@ fn parse_shape(
                 .split_whitespace()
                 .filter_map(|s| s.parse().ok())
                 .collect();
-            for i in (0..coords.len().saturating_sub(2)).step_by(2) {
+            for i in (0..coords.len().saturating_sub(3)).step_by(2) {
                 let start = [
                     mil_to_mm(coords[i] - origin_x),
                     mil_to_mm(coords[i + 1] - origin_y),
@@ -357,7 +357,7 @@ fn parse_easyeda_component(
                         .split_whitespace()
                         .filter_map(|c| c.parse().ok())
                         .collect();
-                    for i in (0..coords.len().saturating_sub(2)).step_by(2) {
+                    for i in (0..coords.len().saturating_sub(3)).step_by(2) {
                         let start = [
                             mil_to_mm(coords[i] - origin_x),
                             mil_to_mm(coords[i + 1] - origin_y),
@@ -546,5 +546,22 @@ fn easyeda_layer_to_side(layer_id: u32) -> &'static str {
         2 | 4 | 6 | 13 => "B",
         11 => "F", // Multi-layer, treat as front
         _ => "F",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn odd_length_track_coords_do_not_panic() {
+        // A TRACK with an odd number of coordinate values must not index past
+        // the end of the coordinate list.
+        let json = br#"{"shape":["TRACK~1~1~0 0 5"]}"#;
+        let opts = ExtractOptions {
+            include_tracks: true,
+            include_nets: true,
+        };
+        assert!(parse(json, &opts).is_ok());
     }
 }

--- a/crates/pcb-extract/src/parsers/gerber/excellon.rs
+++ b/crates/pcb-extract/src/parsers/gerber/excellon.rs
@@ -211,8 +211,8 @@ fn parse_coordinate_line(
     zero_sup: ZeroSuppression,
     format: CoordFormat,
 ) -> Option<(f64, f64)> {
-    let mut x_str: Option<&str> = None;
-    let mut y_str: Option<&str> = None;
+    let mut x_str: Option<String> = None;
+    let mut y_str: Option<String> = None;
 
     let mut i = 0;
     let chars: Vec<char> = line.chars().collect();
@@ -221,21 +221,21 @@ fn parse_coordinate_line(
             'X' => {
                 let start = i + 1;
                 let end = find_next_letter(&chars, start);
-                x_str = Some(&line[start..end]);
+                x_str = Some(chars[start..end].iter().collect());
                 i = end;
             }
             'Y' => {
                 let start = i + 1;
                 let end = find_next_letter(&chars, start);
-                y_str = Some(&line[start..end]);
+                y_str = Some(chars[start..end].iter().collect());
                 i = end;
             }
             _ => i += 1,
         }
     }
 
-    let x = parse_coord_value(x_str?, units, zero_sup, format)?;
-    let y = parse_coord_value(y_str?, units, zero_sup, format)?;
+    let x = parse_coord_value(&x_str?, units, zero_sup, format)?;
+    let y = parse_coord_value(&y_str?, units, zero_sup, format)?;
     Some((x, y))
 }
 
@@ -539,5 +539,22 @@ M30
             }
             _ => panic!("Expected Circle"),
         }
+    }
+
+    #[test]
+    fn test_multibyte_coordinate_does_not_panic() {
+        // A stray multibyte character in a coordinate line must not trigger a
+        // char-boundary slicing panic.
+        let content = "\
+M48
+METRIC,TZ,000.000
+T01C0.300
+%
+T01
+X1°Y2
+M30
+";
+        // The malformed hit is dropped; the parser must not panic.
+        let _ = parse_excellon(content);
     }
 }


### PR DESCRIPTION
Two attacker-reachable panics when parsing untrusted uploads:

- **#207** — the EasyEDA `TRACK` loop used `coords.len().saturating_sub(2)` as its bound but then read `coords[i + 3]`, so any track with an odd coordinate count ≥ 3 indexed past the end and panicked. Bounded to complete point-pairs (`saturating_sub(3)`), fixed at both call sites.
- **#208** — the Excellon coordinate parser computed `start`/`end` as indices into a `Vec<char>` but used them to byte-slice the original `&str`, panicking with "byte index is not a char boundary" on any multibyte character. Now builds the substring from the char vec.

Both get regression tests; full suite is 225 green, clippy `-D warnings` clean.

Closes #207, #208