### PR TITLE
Bound parser allocations and recursion against crafted input

### DIFF
--- a/crates/pcb-extract/src/parsers/eagle_binary.rs
+++ b/crates/pcb-extract/src/parsers/eagle_binary.rs
@@ -6,6 +6,10 @@ use std::collections::HashMap;
 
 // ─── Constants ──────────────────────────────────────────────────────
 
+/// Maximum section nesting depth. Guards the recursive section parser against
+/// a stack overflow on a crafted chain of nested sections.
+const MAX_SECTION_DEPTH: usize = 1000;
+
 const SEC_START: u8 = 0x10;
 const SEC_LIBRARY: u8 = 0x15;
 const SEC_PACKAGES: u8 = 0x19;
@@ -265,7 +269,7 @@ fn build_section_tree(records: &[RawRecord]) -> Result<Section, ExtractError> {
     }
 
     let mut idx = 0;
-    let root = parse_section_recursive(records, &mut idx)?;
+    let root = parse_section_recursive(records, &mut idx, 0)?;
     Ok(root)
 }
 
@@ -311,7 +315,13 @@ fn subsection_counts(rec: &RawRecord) -> Vec<usize> {
 fn parse_section_recursive(
     records: &[RawRecord],
     idx: &mut usize,
+    depth: usize,
 ) -> Result<Section, ExtractError> {
+    if depth >= MAX_SECTION_DEPTH {
+        return Err(ExtractError::ParseError(
+            "Eagle binary: section nesting too deep".to_string(),
+        ));
+    }
     if *idx >= records.len() {
         return Err(ExtractError::ParseError(
             "Eagle binary: unexpected end of sections".to_string(),
@@ -330,7 +340,7 @@ fn parse_section_recursive(
     let mut consumed = 0;
     while consumed < budget && *idx < records.len() {
         let before = *idx;
-        children.push(parse_section_recursive(records, idx)?);
+        children.push(parse_section_recursive(records, idx, depth + 1)?);
         consumed += *idx - before;
     }
 

--- a/crates/pcb-extract/src/parsers/gdsii.rs
+++ b/crates/pcb-extract/src/parsers/gdsii.rs
@@ -96,6 +96,10 @@ const DT_ASCII: u8 = 0x06;
 /// Maximum number of flattened elements before stopping.
 const MAX_FLATTEN_ELEMENTS: usize = 500_000;
 
+/// Maximum number of AREF array instances. COLROW counts are file-controlled
+/// `i16`s; this bounds the replication loop against crafted values.
+const MAX_AREF_INSTANCES: usize = 1_000_000;
+
 /// Maximum number of footprints to generate.
 const MAX_FOOTPRINTS: usize = 5_000;
 
@@ -1029,8 +1033,13 @@ fn flatten_structure(
                             let p1 = xy_to_mm(xy[1].0, xy[1].1, scale);
                             let p2 = xy_to_mm(xy[2].0, xy[2].1, scale);
 
-                            let ncols = *cols as usize;
-                            let nrows = *rows as usize;
+                            let mut ncols = (*cols).max(0) as usize;
+                            let mut nrows = (*rows).max(0) as usize;
+                            // Reject negative (sign-extended) or oversized arrays.
+                            if ncols.saturating_mul(nrows) > MAX_AREF_INSTANCES {
+                                ncols = 0;
+                                nrows = 0;
+                            }
 
                             let col_dx = if ncols > 1 {
                                 (p1[0] - p0[0]) / ncols as f64
@@ -1055,10 +1064,10 @@ fn flatten_structure(
 
                             let ref_mirror = (strans & 0x8000) != 0;
 
-                            for r in 0..nrows {
+                            'rows: for r in 0..nrows {
                                 for c in 0..ncols {
                                     if local.element_count() >= MAX_FLATTEN_ELEMENTS {
-                                        break;
+                                        break 'rows;
                                     }
                                     let inst_origin = [
                                         p0[0] + c as f64 * col_dx + r as f64 * row_dx,

--- a/crates/pcb-extract/src/parsers/gerber/interpreter.rs
+++ b/crates/pcb-extract/src/parsers/gerber/interpreter.rs
@@ -11,6 +11,15 @@ use super::commands::{ApertureTemplate, GerberCommand, Polarity};
 use super::coord::CoordinateConverter;
 use super::macros::{self, MacroTable};
 
+/// Upper bound on regular-polygon vertices. Real polygon apertures have a
+/// handful of vertices; this caps a crafted count before it drives a huge
+/// `Vec::with_capacity`.
+pub(super) const MAX_POLYGON_VERTICES: usize = 1024;
+
+/// Upper bound on the total drawings produced by a single step-and-repeat
+/// block, defending against crafted `%SR%` repeat counts.
+const MAX_SR_DRAWINGS: usize = 2_000_000;
+
 /// Output from interpreting a single Gerber file.
 #[derive(Debug, Default)]
 pub struct GerberLayerOutput {
@@ -276,24 +285,40 @@ impl Interpreter {
 
         let block: Vec<Drawing> = self.drawings[start..].to_vec();
 
-        for yi in 0..self.sr_y_repeat {
-            for xi in 0..self.sr_x_repeat {
-                if xi == 0 && yi == 0 {
-                    continue; // original position already drawn
-                }
-                let dx = xi as f64 * self.sr_x_step;
-                let dy = yi as f64 * self.sr_y_step;
-                for d in &block {
-                    self.drawings.push(offset_drawing(d, dx, dy));
-                }
-            }
-        }
+        let x_repeat = self.sr_x_repeat;
+        let y_repeat = self.sr_y_repeat;
+        let x_step = self.sr_x_step;
+        let y_step = self.sr_y_step;
 
-        // Reset SR state to defaults.
+        // Reset SR state to defaults before replicating.
         self.sr_x_repeat = 1;
         self.sr_y_repeat = 1;
         self.sr_x_step = 0.0;
         self.sr_y_step = 0.0;
+
+        if block.is_empty() {
+            return;
+        }
+
+        // Bound total replicated drawings against crafted repeat counts.
+        let budget = MAX_SR_DRAWINGS.saturating_sub(self.drawings.len());
+        let mut pushed = 0usize;
+        'replicate: for yi in 0..y_repeat {
+            for xi in 0..x_repeat {
+                if xi == 0 && yi == 0 {
+                    continue; // original position already drawn
+                }
+                let dx = xi as f64 * x_step;
+                let dy = yi as f64 * y_step;
+                for d in &block {
+                    if pushed >= budget {
+                        break 'replicate;
+                    }
+                    self.drawings.push(offset_drawing(d, dx, dy));
+                    pushed += 1;
+                }
+            }
+        }
     }
 
     fn do_interpolate(&mut self, old_x: i64, old_y: i64, i: Option<i64>, j: Option<i64>) {
@@ -390,7 +415,7 @@ impl Interpreter {
                     rotation,
                 } => {
                     let r = outer_diameter / 2.0;
-                    let n = *num_vertices as usize;
+                    let n = (*num_vertices as usize).min(MAX_POLYGON_VERTICES);
                     let rot_rad = rotation.to_radians();
                     let mut points = Vec::with_capacity(n);
                     for k in 0..n {

--- a/crates/pcb-extract/src/parsers/gerber/macros.rs
+++ b/crates/pcb-extract/src/parsers/gerber/macros.rs
@@ -4,6 +4,16 @@ use std::f64::consts::PI;
 use crate::error::ExtractError;
 use crate::types::Drawing;
 
+use super::interpreter::MAX_POLYGON_VERTICES;
+
+/// Maximum parenthesis nesting depth in a macro expression. Guards the
+/// recursive-descent parser against stack overflow on crafted input.
+const MAX_EXPR_DEPTH: usize = 256;
+
+/// Maximum token count in a macro expression. Bounds both the parse work and
+/// the depth of `Expr::eval` on a long left-associative chain.
+const MAX_EXPR_TOKENS: usize = 4096;
+
 /// A single primitive within an aperture macro definition.
 #[derive(Debug, Clone, PartialEq)]
 pub enum MacroPrimitive {
@@ -135,7 +145,7 @@ pub fn parse_expr(s: &str) -> Result<Expr, ExtractError> {
         return Ok(Expr::Literal(0.0));
     }
     let tokens = tokenize_expr(s)?;
-    let (expr, rest) = parse_add_sub(&tokens)?;
+    let (expr, rest) = parse_add_sub(&tokens, 0)?;
     if !rest.is_empty() {
         return Err(ExtractError::ParseError(format!(
             "AM expr: unexpected tokens after expression: {s}"
@@ -161,6 +171,11 @@ fn tokenize_expr(s: &str) -> Result<Vec<ExprToken>, ExtractError> {
     let mut chars = s.chars().peekable();
 
     while let Some(&ch) = chars.peek() {
+        if tokens.len() >= MAX_EXPR_TOKENS {
+            return Err(ExtractError::ParseError(
+                "AM expr: expression too long".into(),
+            ));
+        }
         match ch {
             ' ' | '\t' => {
                 chars.next();
@@ -252,17 +267,20 @@ fn tokenize_expr(s: &str) -> Result<Vec<ExprToken>, ExtractError> {
 }
 
 // Recursive descent: add/sub -> mul/div -> atom
-fn parse_add_sub(tokens: &[ExprToken]) -> Result<(Expr, &[ExprToken]), ExtractError> {
-    let (mut left, mut rest) = parse_mul_div(tokens)?;
+fn parse_add_sub(tokens: &[ExprToken], depth: usize) -> Result<(Expr, &[ExprToken]), ExtractError> {
+    if depth > MAX_EXPR_DEPTH {
+        return Err(ExtractError::ParseError("AM expr: nesting too deep".into()));
+    }
+    let (mut left, mut rest) = parse_mul_div(tokens, depth)?;
     loop {
         match rest.first() {
             Some(ExprToken::Plus) => {
-                let (right, r) = parse_mul_div(&rest[1..])?;
+                let (right, r) = parse_mul_div(&rest[1..], depth)?;
                 left = Expr::Add(Box::new(left), Box::new(right));
                 rest = r;
             }
             Some(ExprToken::Minus) => {
-                let (right, r) = parse_mul_div(&rest[1..])?;
+                let (right, r) = parse_mul_div(&rest[1..], depth)?;
                 left = Expr::Sub(Box::new(left), Box::new(right));
                 rest = r;
             }
@@ -272,17 +290,17 @@ fn parse_add_sub(tokens: &[ExprToken]) -> Result<(Expr, &[ExprToken]), ExtractEr
     Ok((left, rest))
 }
 
-fn parse_mul_div(tokens: &[ExprToken]) -> Result<(Expr, &[ExprToken]), ExtractError> {
-    let (mut left, mut rest) = parse_atom(tokens)?;
+fn parse_mul_div(tokens: &[ExprToken], depth: usize) -> Result<(Expr, &[ExprToken]), ExtractError> {
+    let (mut left, mut rest) = parse_atom(tokens, depth)?;
     loop {
         match rest.first() {
             Some(ExprToken::Mul) => {
-                let (right, r) = parse_atom(&rest[1..])?;
+                let (right, r) = parse_atom(&rest[1..], depth)?;
                 left = Expr::Mul(Box::new(left), Box::new(right));
                 rest = r;
             }
             Some(ExprToken::Div) => {
-                let (right, r) = parse_atom(&rest[1..])?;
+                let (right, r) = parse_atom(&rest[1..], depth)?;
                 left = Expr::Div(Box::new(left), Box::new(right));
                 rest = r;
             }
@@ -292,12 +310,12 @@ fn parse_mul_div(tokens: &[ExprToken]) -> Result<(Expr, &[ExprToken]), ExtractEr
     Ok((left, rest))
 }
 
-fn parse_atom(tokens: &[ExprToken]) -> Result<(Expr, &[ExprToken]), ExtractError> {
+fn parse_atom(tokens: &[ExprToken], depth: usize) -> Result<(Expr, &[ExprToken]), ExtractError> {
     match tokens.first() {
         Some(ExprToken::Num(v)) => Ok((Expr::Literal(*v), &tokens[1..])),
         Some(ExprToken::Var(idx)) => Ok((Expr::Variable(*idx), &tokens[1..])),
         Some(ExprToken::LParen) => {
-            let (expr, rest) = parse_add_sub(&tokens[1..])?;
+            let (expr, rest) = parse_add_sub(&tokens[1..], depth + 1)?;
             match rest.first() {
                 Some(ExprToken::RParen) => Ok((expr, &rest[1..])),
                 _ => Err(ExtractError::ParseError(
@@ -605,7 +623,7 @@ pub fn evaluate_macro(
                 if exp < 0.5 {
                     continue;
                 }
-                let n = num_vertices.eval(params) as usize;
+                let n = (num_vertices.eval(params) as usize).min(MAX_POLYGON_VERTICES);
                 let cx = center_x.eval(params);
                 let cy = center_y.eval(params);
                 let d = diameter.eval(params);
@@ -720,6 +738,21 @@ mod tests {
     fn test_expr_multiply() {
         let expr = parse_expr("1.08239X$1").unwrap();
         assert_abs_diff_eq!(expr.eval(&[0.1]), 0.108239, epsilon = 1e-9);
+    }
+
+    #[test]
+    fn rejects_deeply_nested_expression() {
+        // Many nested parens must be rejected, not stack-overflow the parser.
+        let deep = format!("{}1{}", "(".repeat(5000), ")".repeat(5000));
+        assert!(parse_expr(&deep).is_err());
+    }
+
+    #[test]
+    fn rejects_overly_long_expression() {
+        // A long left-associative chain is rejected before building a tree that
+        // would overflow the stack during eval.
+        let long = "1+".repeat(10_000) + "1";
+        assert!(parse_expr(&long).is_err());
     }
 
     #[test]

--- a/crates/pcb-extract/src/parsers/kicad.rs
+++ b/crates/pcb-extract/src/parsers/kicad.rs
@@ -198,10 +198,17 @@ fn layer_is_copper(name: &str) -> bool {
 
 // ─── Nets ────────────────────────────────────────────────────────────
 
+/// Upper bound on net ids. KiCad assigns sequential ids, so a value beyond this
+/// is malformed; the cap prevents a crafted id from forcing a huge allocation.
+const MAX_NET_ID: usize = 1_000_000;
+
 fn parse_nets(root: &SExpr) -> Vec<String> {
     let mut nets = Vec::new();
     for child in root.find_all("net") {
         let id = child.f64_at(0).unwrap_or(0.0) as usize;
+        if id > MAX_NET_ID {
+            continue;
+        }
         let name = child.atom_at(1).unwrap_or("").to_string();
         while nets.len() <= id {
             nets.push(String::new());

--- a/crates/pcb-extract/src/parsers/kicad_sexpr.rs
+++ b/crates/pcb-extract/src/parsers/kicad_sexpr.rs
@@ -1,11 +1,15 @@
-/// S-expression parser for KiCad files.
-///
-/// Grammar:
-///   sexpr  = '(' atom_or_sexpr* ')'
-///   atom   = string | number | symbol
-///   string = '"' [^"]* '"'  (with escape handling)
-///   number = [-]?[0-9]+[.[0-9]*]?
-///   symbol = [^ \t\n\r()"]+
+//! S-expression parser for KiCad files.
+//!
+//! Grammar:
+//!   sexpr  = '(' atom_or_sexpr* ')'
+//!   atom   = string | number | symbol
+//!   string = '"' [^"]* '"'  (with escape handling)
+//!   number = [-]?[0-9]+[.[0-9]*]?
+//!   symbol = [^ \t\n\r()"]+
+
+/// Maximum S-expression nesting depth. Guards the recursive parser against a
+/// stack overflow on crafted, deeply-nested input.
+const MAX_SEXPR_DEPTH: usize = 1000;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum SExpr {
@@ -164,9 +168,19 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_sexpr(&mut self) -> Option<SExpr> {
+        self.parse_sexpr_depth(0)
+    }
+
+    fn parse_sexpr_depth(&mut self, depth: usize) -> Option<SExpr> {
         self.skip_whitespace();
         match self.peek()? {
             b'(' => {
+                if depth >= MAX_SEXPR_DEPTH {
+                    // Too deeply nested — abandon parsing rather than risk a
+                    // stack overflow on crafted input.
+                    self.pos = self.input.len();
+                    return None;
+                }
                 self.pos += 1;
                 let mut items = Vec::new();
                 loop {
@@ -178,7 +192,7 @@ impl<'a> Parser<'a> {
                         }
                         None => break,
                         _ => {
-                            if let Some(expr) = self.parse_sexpr() {
+                            if let Some(expr) = self.parse_sexpr_depth(depth + 1) {
                                 items.push(expr);
                             }
                         }
@@ -218,6 +232,14 @@ mod tests {
         assert_eq!(result.tag(), Some("a"));
         assert_eq!(result.value("b"), Some("1"));
         assert_eq!(result.value("c"), Some("2"));
+    }
+
+    #[test]
+    fn deeply_nested_input_does_not_overflow() {
+        // A pathological run of open parens must not blow the stack; the parser
+        // bails at the depth limit and returns without recursing unbounded.
+        let input = "(".repeat(100_000);
+        let _ = parse(input.as_bytes());
     }
 
     #[test]

--- a/crates/pcb-extract/src/parsers/odbpp/features.rs
+++ b/crates/pcb-extract/src/parsers/odbpp/features.rs
@@ -1,6 +1,10 @@
 use super::symbols;
 use crate::types::Drawing;
 
+/// Upper bound on the ODB++ symbol-table size; indices are sequential, so a
+/// larger value is malformed and would otherwise force a huge allocation.
+const MAX_SYMBOL_TABLE: usize = 1_000_000;
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Unit {
     Inch,
@@ -83,10 +87,14 @@ pub fn parse_features(content: &str) -> FeatureData {
             if let Some((_idx, name)) = rest.split_once(' ') {
                 let name = name.split_whitespace().next().unwrap_or(name);
                 let idx: usize = _idx.parse().unwrap_or(sym_table.len());
-                while sym_table.len() <= idx {
-                    sym_table.push(String::new());
+                // Bound the table to defend against a crafted index forcing a
+                // huge allocation.
+                if idx < MAX_SYMBOL_TABLE {
+                    while sym_table.len() <= idx {
+                        sym_table.push(String::new());
+                    }
+                    sym_table[idx] = name.to_string();
                 }
-                sym_table[idx] = name.to_string();
             }
             continue;
         }


### PR DESCRIPTION
Hardens the parsers against denial-of-service from malformed uploads. Each of these took a file-controlled length/count/depth and could OOM or stack-overflow the whole process (uncatchable by `spawn_blocking`):

- **#202** KiCad — cap the `(net <id>)` value before growing the nets vec
- **#203** Gerber — bound `%SR%` step-and-repeat replication (running budget) and clamp regular-polygon vertex counts (aperture + macro paths)
- **#204** ODB++ — cap the `$<idx>` symbol-table index
- **#205** Recursion depth limits on the KiCad s-expression parser, the Eagle binary section parser, and the Gerber macro expression parser; plus a token-count cap so a long flat `1+1+…` chain can't deep-recurse in `Expr::eval`
- **#206** GDSII — clamp AREF `COLROW` counts, rejecting negative (sign-extended) or oversized arrays, and break the outer replication loop at the element cap

New regression tests cover the recursion and expression-size limits; full suite 226 green, clippy `-D warnings` clean.

Closes #202, #203, #204, #205, #206