### PR TITLE
Fix inner-layer double-draw and thumbnail/viewer parity

### DIFF
--- a/crates/pcb-extract/src/thumbnail.rs
+++ b/crates/pcb-extract/src/thumbnail.rs
@@ -98,7 +98,7 @@ fn render_drawings(svg: &mut String, drawings: &[Drawing], color: &str) {
                 width,
                 filled,
             } => {
-                if filled.is_some() {
+                if filled.is_some_and(|f| f != 0) {
                     write!(
                         svg,
                         r#"<circle cx="{:.4}" cy="{:.4}" r="{:.4}" fill="{color}"/>"#,
@@ -122,20 +122,13 @@ fn render_drawings(svg: &mut String, drawings: &[Drawing], color: &str) {
                 let y = start[1].min(end[1]);
                 let rw = (end[0] - start[0]).abs();
                 let rh = (end[1] - start[1]).abs();
-                if *width < 0.01 {
-                    write!(
-                        svg,
-                        r#"<rect x="{x:.4}" y="{y:.4}" width="{rw:.4}" height="{rh:.4}" fill="{color}"/>"#,
-                    )
-                    .unwrap();
-                } else {
-                    write!(
-                        svg,
-                        r#"<rect x="{x:.4}" y="{y:.4}" width="{rw:.4}" height="{rh:.4}" fill="none" stroke="{color}" stroke-width="{:.4}"/>"#,
-                        width,
-                    )
-                    .unwrap();
-                }
+                // Match the viewer, which always strokes rectangle outlines.
+                let sw = if *width < 0.1 { 0.1 } else { *width };
+                write!(
+                    svg,
+                    r#"<rect x="{x:.4}" y="{y:.4}" width="{rw:.4}" height="{rh:.4}" fill="none" stroke="{color}" stroke-width="{sw:.4}"/>"#,
+                )
+                .unwrap();
             }
             Drawing::Arc {
                 start,
@@ -158,8 +151,9 @@ fn render_drawings(svg: &mut String, drawings: &[Drawing], color: &str) {
                         continue;
                     }
                     let mut d = String::new();
-                    let cos_a = angle.to_radians().cos();
-                    let sin_a = angle.to_radians().sin();
+                    // Match the viewer, which rotates polygons by -angle.
+                    let cos_a = (-*angle).to_radians().cos();
+                    let sin_a = (-*angle).to_radians().sin();
                     for (i, pt) in poly.iter().enumerate() {
                         let rx = pt[0] * cos_a - pt[1] * sin_a + pos[0];
                         let ry = pt[0] * sin_a + pt[1] * cos_a + pos[1];
@@ -170,7 +164,7 @@ fn render_drawings(svg: &mut String, drawings: &[Drawing], color: &str) {
                         }
                     }
                     d.push('Z');
-                    if filled.is_some() {
+                    if filled.is_none_or(|f| f != 0) {
                         write!(svg, r#"<path d="{d}" fill="{color}" fill-rule="evenodd"/>"#)
                             .unwrap();
                     } else {
@@ -557,7 +551,8 @@ mod tests {
     }
 
     #[test]
-    fn test_rect_drawing_filled() {
+    fn test_rect_drawing_zero_width_strokes() {
+        // A zero-width rect strokes (with a minimum width), matching the viewer.
         let mut data = minimal_pcbdata();
         data.edges.push(Drawing::Rect {
             start: [5.0, 5.0],
@@ -568,6 +563,7 @@ mod tests {
         let rect_count = svg.matches("<rect").count();
         // background rect + edge rect
         assert!(rect_count >= 2);
+        assert!(svg.contains(&format!("stroke=\"{EDGE_COLOR}\"")));
     }
 
     #[test]
@@ -660,17 +656,33 @@ mod tests {
 
     #[test]
     fn test_polygon_stroked() {
+        // filled: Some(0) means explicitly not filled — matches the viewer.
         let mut data = minimal_pcbdata();
         data.drawings.silkscreen.front.push(Drawing::Polygon {
             pos: [10.0, 10.0],
             angle: 0.0,
             polygons: vec![vec![[0.0, 0.0], [5.0, 0.0], [5.0, 5.0]]],
-            filled: None,
+            filled: Some(0),
             width: 0.3,
         });
         let svg = render_svg(&data);
         assert!(svg.contains("fill=\"none\""));
         assert!(svg.contains(&format!("stroke=\"{SILK_COLOR}\"")));
+    }
+
+    #[test]
+    fn test_polygon_none_is_filled() {
+        // filled: None defaults to filled, matching the viewer's is_none_or.
+        let mut data = minimal_pcbdata();
+        data.drawings.silkscreen.front.push(Drawing::Polygon {
+            pos: [10.0, 10.0],
+            angle: 0.0,
+            polygons: vec![vec![[0.0, 0.0], [5.0, 0.0], [5.0, 5.0], [0.0, 5.0]]],
+            filled: None,
+            width: 0.0,
+        });
+        let svg = render_svg(&data);
+        assert!(svg.contains("fill-rule=\"evenodd\""));
     }
 
     #[test]
@@ -684,8 +696,8 @@ mod tests {
             width: 0.0,
         });
         let svg = render_svg(&data);
-        // After 45° rotation, [1,0] → [cos45, sin45] ≈ [0.7071, 0.7071]
-        assert!(svg.contains("M0.7071 0.7071"));
+        // Viewer rotates by -angle, so [1,0] → [cos45, -sin45] ≈ [0.7071, -0.7071]
+        assert!(svg.contains("M0.7071 -0.7071"));
     }
 
     #[test]

--- a/crates/viewer/src/render.rs
+++ b/crates/viewer/src/render.rs
@@ -1048,6 +1048,7 @@ pub fn draw_nets(
     settings: &Settings,
     highlighted_net: &Option<String>,
     zone_cache: &mut HashMap<String, Path2d>,
+    draw_inner: bool,
 ) {
     let track_color = if highlight {
         &colors.track_highlight
@@ -1075,7 +1076,7 @@ pub fn draw_nets(
             zone_cache,
         );
         // Dimmed inner-layer zones, gated by the same hidden_layers toggle as inner tracks.
-        if let Some(ref zones) = pcbdata.zones {
+        if let (true, Some(ref zones)) = (draw_inner, &pcbdata.zones) {
             let ctx = get_ctx(canvas);
             ctx.save();
             ctx.set_global_alpha(0.25);
@@ -1106,7 +1107,7 @@ pub fn draw_nets(
             highlighted_net,
         );
         // Also draw inner copper layer tracks (not zones - those are plane fills)
-        if let Some(ref tracks) = pcbdata.tracks {
+        if let (true, Some(ref tracks)) = (draw_inner, &pcbdata.tracks) {
             let ctx = get_ctx(canvas);
             ctx.save();
             ctx.set_global_alpha(0.25);
@@ -1285,6 +1286,7 @@ pub fn draw_background(
         settings,
         highlighted_net,
         zone_cache,
+        false,
     );
     if settings.render_tracks {
         let opp_color = if opposite == "F" {
@@ -1314,7 +1316,7 @@ pub fn draw_background(
     );
     get_ctx(&layer.bg).restore();
 
-    // Draw primary layer at full opacity
+    // Draw primary layer at full opacity (inner layers drawn once, here)
     draw_nets(
         &layer.bg,
         &layer.layer,
@@ -1324,6 +1326,7 @@ pub fn draw_background(
         settings,
         highlighted_net,
         zone_cache,
+        true,
     );
     if settings.render_tracks {
         let primary_color = if layer.layer == "F" {
@@ -1459,6 +1462,7 @@ pub fn draw_highlights_on_layer(
             settings,
             highlighted_net,
             zone_cache,
+            false,
         );
         draw_nets(
             &layer.highlight,
@@ -1469,6 +1473,7 @@ pub fn draw_highlights_on_layer(
             settings,
             highlighted_net,
             zone_cache,
+            true,
         );
     }
 }


### PR DESCRIPTION
**#214** — `draw_background` (and `draw_highlights_on_layer`) called `draw_nets` twice (opposite + primary layer), and `draw_nets` itself redrew *all* inner copper layers each call. So inner zones/tracks were drawn twice per frame and composited to ~0.44 alpha instead of the intended 0.25. Added a `draw_inner` flag so inner layers render exactly once (in the primary pass).

**#215** — aligned the SVG thumbnail (`thumbnail.rs`) with the viewer's `PcbData` semantics, which per CLAUDE.md the two paths must share:
- Circle fills only on `Some(non-zero)` (was `is_some()`, so `Some(0)` wrongly filled)
- Polygon fills on `None` or `Some(non-zero)` (was `is_some()`, inverted for both `None` and `Some(0)`)
- Polygons rotate by `-angle` to match the viewer (was `+angle`)
- Rectangles always stroke (was filling zero-width rects)

Thumbnail tests updated to the viewer's semantics; full suite 224 green, both clippy gates clean.

Closes #214, #215