### PR TITLE
Sanitize client-controlled storage keys and gh-render input

### DIFF
--- a/crates/server/src/github.rs
+++ b/crates/server/src/github.rs
@@ -16,6 +16,21 @@ pub struct GhRenderParams {
     /// Optional branch/tag override
     #[serde(rename = "ref")]
     git_ref: Option<String>,
+    /// When true, don't add the render to the public recent list.
+    #[serde(default)]
+    secret: bool,
+}
+
+/// Validate a git ref (branch/tag/sha) before it is interpolated into storage
+/// keys and GitHub URLs. Git refs may contain `/` but not `..`.
+fn valid_git_ref(r: &str) -> bool {
+    !r.is_empty()
+        && r.len() <= 256
+        && !r.contains("..")
+        && !r.starts_with('/')
+        && !r.ends_with('/')
+        && r.chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-' | '/'))
 }
 
 #[derive(Serialize, Deserialize)]
@@ -62,6 +77,9 @@ async fn gh_render_inner(
 
     // Resolve git ref: explicit, or try main then master
     let git_ref = if let Some(r) = params.git_ref {
+        if !valid_git_ref(&r) {
+            return Err("Invalid ref".to_string());
+        }
         r
     } else {
         resolve_default_ref(&state.http_client, &repo, &path).await?
@@ -161,18 +179,20 @@ async fn gh_render_inner(
             .await;
     }
 
-    // Add to recent list
-    crate::routes::add_recent(
-        &state,
-        crate::routes::RecentEntry {
-            id: bom_id.clone(),
-            filename: filename.clone(),
-            components: component_count,
-            file_size,
-            created: chrono::Utc::now().to_rfc3339(),
-        },
-    )
-    .await;
+    // Add to recent list unless the caller opted out.
+    if !params.secret {
+        crate::routes::add_recent(
+            &state,
+            crate::routes::RecentEntry {
+                id: bom_id.clone(),
+                filename: filename.clone(),
+                components: component_count,
+                file_size,
+                created: chrono::Utc::now().to_rfc3339(),
+            },
+        )
+        .await;
+    }
 
     // Render thumbnail
     let svg = tokio::task::spawn_blocking(move || pcb_extract::thumbnail::render_svg(&pcb_data))
@@ -343,6 +363,26 @@ async fn download_raw(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn valid_git_ref_accepts_normal_refs() {
+        assert!(valid_git_ref("main"));
+        assert!(valid_git_ref("master"));
+        assert!(valid_git_ref("feature/new-board"));
+        assert!(valid_git_ref("v1.2.3"));
+        assert!(valid_git_ref("a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0"));
+    }
+
+    #[test]
+    fn valid_git_ref_rejects_traversal_and_junk() {
+        assert!(!valid_git_ref(""));
+        assert!(!valid_git_ref("../../etc/passwd"));
+        assert!(!valid_git_ref(".."));
+        assert!(!valid_git_ref("/main"));
+        assert!(!valid_git_ref("main/"));
+        assert!(!valid_git_ref("main?ref=x"));
+        assert!(!valid_git_ref("a b"));
+    }
 
     #[test]
     fn test_error_svg_is_valid_svg() {

--- a/crates/server/src/routes.rs
+++ b/crates/server/src/routes.rs
@@ -61,6 +61,31 @@ pub struct RecentEntry {
     pub created: String,
 }
 
+/// Reduce a client-supplied filename to a single safe path component for use
+/// in a storage key, preventing traversal (`../`) on the filesystem backend.
+fn safe_filename(name: &str) -> String {
+    let base = std::path::Path::new(name)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("");
+    let cleaned: String = base
+        .chars()
+        .filter(|c| !matches!(c, '/' | '\\' | '\0'))
+        .collect();
+    if cleaned.is_empty() || cleaned == "." || cleaned == ".." {
+        "upload.bin".to_string()
+    } else {
+        cleaned
+    }
+}
+
+/// Reject ids that aren't UUIDs so they can't traverse the storage root.
+fn validate_id(id: &str) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+    Uuid::parse_str(id)
+        .map(|_| ())
+        .map_err(|_| error_response(StatusCode::NOT_FOUND, "BOM not found"))
+}
+
 fn is_supported_format(filename: &str) -> bool {
     let name = filename.to_lowercase();
     !name.ends_with(".gds") && !name.ends_with(".gds2")
@@ -234,8 +259,9 @@ async fn upload(
     let file_size = data.len();
     let id = Uuid::new_v4().to_string();
 
-    // Always store the original upload first
-    let upload_key = format!("uploads/{id}/{filename}");
+    // Always store the original upload first (sanitize the client filename so
+    // it can't escape the upload directory on the filesystem backend).
+    let upload_key = format!("uploads/{id}/{}", safe_filename(&filename));
     let _ = state
         .s3
         .put_object(&upload_key, data.clone(), "application/octet-stream")
@@ -311,6 +337,7 @@ async fn get_bom(
     State(state): State<AppState>,
     Path(id): Path<String>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<ErrorResponse>)> {
+    validate_id(&id)?;
     // Verify the BOM exists
     let key = format!("boms/{id}.json");
     let _ = state
@@ -332,6 +359,7 @@ async fn get_bom_data(
     State(state): State<AppState>,
     Path(id): Path<String>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<ErrorResponse>)> {
+    validate_id(&id)?;
     let key = format!("boms/{id}.json");
     let json_bytes = state
         .s3
@@ -349,6 +377,7 @@ async fn get_meta(
     State(state): State<AppState>,
     Path(id): Path<String>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<ErrorResponse>)> {
+    validate_id(&id)?;
     let key = format!("boms/{id}.meta.json");
     let meta_bytes = state
         .s3
@@ -365,6 +394,7 @@ async fn get_thumb_svg(
     State(state): State<AppState>,
     Path(id): Path<String>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<ErrorResponse>)> {
+    validate_id(&id)?;
     let thumb_key = format!("thumbnails/{id}.svg");
 
     // Try cache first
@@ -427,4 +457,35 @@ fn error_response(status: StatusCode, msg: &str) -> (StatusCode, Json<ErrorRespo
             error: msg.to_string(),
         }),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn safe_filename_strips_traversal() {
+        assert_eq!(safe_filename("../../etc/passwd"), "passwd");
+        assert_eq!(safe_filename("/abs/board.kicad_pcb"), "board.kicad_pcb");
+        assert_eq!(safe_filename("board.kicad_pcb"), "board.kicad_pcb");
+        assert_eq!(safe_filename(".."), "upload.bin");
+        assert_eq!(safe_filename(""), "upload.bin");
+    }
+
+    #[test]
+    fn safe_filename_has_no_separators() {
+        for name in ["../../x", "a/b/c", "x\\y", "..\\..\\y"] {
+            let s = safe_filename(name);
+            assert!(!s.contains('/') && !s.contains('\\'), "{name} -> {s}");
+        }
+    }
+
+    #[test]
+    fn validate_id_accepts_uuid_rejects_traversal() {
+        let id = Uuid::new_v4().to_string();
+        assert!(validate_id(&id).is_ok());
+        assert!(validate_id("../../etc/passwd").is_err());
+        assert!(validate_id("not-a-uuid").is_err());
+        assert!(validate_id("../boms/secret").is_err());
+    }
 }


### PR DESCRIPTION
Closes the path-traversal class of bugs (filesystem storage backend) and limits gh-render abuse. All keys built from client input are now validated:

- **#199** — `upload` built `uploads/{id}/{filename}` from the raw multipart filename, so `../../…` escaped the upload dir (`root.join` doesn't normalize `..`). Now reduced to a safe basename.
- **#200** — the gh-render `git_ref` was interpolated into the cache key (and GitHub URLs) without the `..` check applied to `file`. Now validated (branch/tag/sha charset, no `..`).
- **#201** — `/b/{id}` handlers built `boms/{id}.json` etc. from an unvalidated param; now require a UUID.
- **#211** — gh-render always added renders to the public recent list; added a `secret` opt-out matching `/upload`, plus the `git_ref` validation above limits the SSRF-ish raw-URL traversal.

S3 keys are unaffected by traversal (`..` is literal there); these protect the filesystem backend used locally/in dev. New unit tests cover each validator; 18 server tests pass, clippy `-D warnings` clean.

Closes #199, #200, #201, #211