### PR TITLE
Extract shared SVG path helpers into pcb_extract::svg

### DIFF
--- a/crates/pcb-extract/src/lib.rs
+++ b/crates/pcb-extract/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod bom;
 pub mod error;
 pub mod parsers;
+pub mod svg;
 pub mod thumbnail;
 pub mod types;
 

--- a/crates/pcb-extract/src/svg.rs
+++ b/crates/pcb-extract/src/svg.rs
@@ -1,0 +1,96 @@
+//! Small SVG path/geometry helpers shared by the SVG render paths.
+//!
+//! Lifted out of `thumbnail.rs` so the thumbnail generator and the GDSII tile
+//! renderer emit identical `d`-strings, view boxes, and stroke widths instead
+//! of each re-implementing them (and drifting).
+
+use std::fmt::Write;
+
+use crate::types::BBox;
+
+/// Open polyline `d`-string: `M x y L x y …` with 4-decimal coordinates.
+/// Points are emitted as given (apply any rotation/offset before calling).
+pub fn polyline_to_d(pts: &[[f64; 2]]) -> String {
+    let mut d = String::with_capacity(pts.len() * 18);
+    for (i, p) in pts.iter().enumerate() {
+        if i == 0 {
+            let _ = write!(d, "M{:.4} {:.4}", p[0], p[1]);
+        } else {
+            let _ = write!(d, "L{:.4} {:.4}", p[0], p[1]);
+        }
+    }
+    d
+}
+
+/// Closed multi-ring polygon `d`-string: each ring rendered as `M…L…Z` and
+/// concatenated (use with `fill-rule="evenodd"` for holes). Rings with fewer
+/// than two points are skipped.
+pub fn poly_to_d(rings: &[Vec<[f64; 2]>]) -> String {
+    let mut d = String::new();
+    for ring in rings {
+        if ring.len() < 2 {
+            continue;
+        }
+        d.push_str(&polyline_to_d(ring));
+        d.push('Z');
+    }
+    d
+}
+
+/// Clamp a stroke width to a minimum visible value so hairline strokes don't
+/// vanish at small scales.
+pub fn stroke_w(w: f64) -> f64 {
+    if w < 0.1 {
+        0.1
+    } else {
+        w
+    }
+}
+
+/// SVG `viewBox` tuple `(x, y, w, h)` for a bbox expanded by `margin` on all
+/// sides.
+pub fn view_box(b: &BBox, margin: f64) -> (f64, f64, f64, f64) {
+    (
+        b.minx - margin,
+        b.miny - margin,
+        (b.maxx - b.minx) + 2.0 * margin,
+        (b.maxy - b.miny) + 2.0 * margin,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn polyline_format() {
+        let d = polyline_to_d(&[[0.0, 0.0], [1.5, 2.0]]);
+        assert_eq!(d, "M0.0000 0.0000L1.5000 2.0000");
+    }
+
+    #[test]
+    fn poly_closes_each_ring() {
+        let d = poly_to_d(&[vec![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]]]);
+        assert_eq!(d, "M0.0000 0.0000L1.0000 0.0000L0.0000 1.0000Z");
+        // sub-2-point rings are skipped
+        assert_eq!(poly_to_d(&[vec![[0.0, 0.0]]]), "");
+    }
+
+    #[test]
+    fn stroke_clamps_below_min() {
+        assert_eq!(stroke_w(0.0), 0.1);
+        assert_eq!(stroke_w(0.05), 0.1);
+        assert_eq!(stroke_w(0.3), 0.3);
+    }
+
+    #[test]
+    fn view_box_expands_by_margin() {
+        let b = BBox {
+            minx: 0.0,
+            miny: 0.0,
+            maxx: 10.0,
+            maxy: 4.0,
+        };
+        assert_eq!(view_box(&b, 2.0), (-2.0, -2.0, 14.0, 8.0));
+    }
+}

--- a/crates/pcb-extract/src/thumbnail.rs
+++ b/crates/pcb-extract/src/thumbnail.rs
@@ -1,3 +1,4 @@
+use crate::svg;
 use crate::types::{Drawing, PcbData};
 use std::fmt::Write;
 
@@ -22,10 +23,7 @@ pub fn render_svg(data: &PcbData) -> String {
         return empty_svg();
     }
 
-    let vx = bbox.minx - MARGIN;
-    let vy = bbox.miny - MARGIN;
-    let vw = w + 2.0 * MARGIN;
-    let vh = h + 2.0 * MARGIN;
+    let (vx, vy, vw, vh) = svg::view_box(bbox, MARGIN);
 
     let mut svg = String::with_capacity(8192);
     write!(
@@ -84,7 +82,7 @@ fn render_drawings(svg: &mut String, drawings: &[Drawing], color: &str) {
     for d in drawings {
         match d {
             Drawing::Segment { start, end, width } => {
-                let sw = if *width < 0.1 { 0.1 } else { *width };
+                let sw = svg::stroke_w(*width);
                 write!(
                     svg,
                     r#"<line x1="{:.4}" y1="{:.4}" x2="{:.4}" y2="{:.4}" stroke="{color}" stroke-width="{sw:.4}" stroke-linecap="round"/>"#,
@@ -106,7 +104,7 @@ fn render_drawings(svg: &mut String, drawings: &[Drawing], color: &str) {
                     )
                     .unwrap();
                 } else {
-                    let sw = if *width < 0.1 { 0.1 } else { *width };
+                    let sw = svg::stroke_w(*width);
                     write!(
                         svg,
                         r#"<circle cx="{:.4}" cy="{:.4}" r="{:.4}" fill="none" stroke="{color}" stroke-width="{sw:.4}"/>"#,
@@ -123,7 +121,7 @@ fn render_drawings(svg: &mut String, drawings: &[Drawing], color: &str) {
                 let rw = (end[0] - start[0]).abs();
                 let rh = (end[1] - start[1]).abs();
                 // Match the viewer, which always strokes rectangle outlines.
-                let sw = if *width < 0.1 { 0.1 } else { *width };
+                let sw = svg::stroke_w(*width);
                 write!(
                     svg,
                     r#"<rect x="{x:.4}" y="{y:.4}" width="{rw:.4}" height="{rh:.4}" fill="none" stroke="{color}" stroke-width="{sw:.4}"/>"#,
@@ -146,29 +144,28 @@ fn render_drawings(svg: &mut String, drawings: &[Drawing], color: &str) {
                 filled,
                 width,
             } => {
+                // Match the viewer, which rotates polygons by -angle.
+                let cos_a = (-*angle).to_radians().cos();
+                let sin_a = (-*angle).to_radians().sin();
                 for poly in polygons {
                     if poly.len() < 2 {
                         continue;
                     }
-                    let mut d = String::new();
-                    // Match the viewer, which rotates polygons by -angle.
-                    let cos_a = (-*angle).to_radians().cos();
-                    let sin_a = (-*angle).to_radians().sin();
-                    for (i, pt) in poly.iter().enumerate() {
-                        let rx = pt[0] * cos_a - pt[1] * sin_a + pos[0];
-                        let ry = pt[0] * sin_a + pt[1] * cos_a + pos[1];
-                        if i == 0 {
-                            write!(d, "M{rx:.4} {ry:.4}").unwrap();
-                        } else {
-                            write!(d, "L{rx:.4} {ry:.4}").unwrap();
-                        }
-                    }
-                    d.push('Z');
+                    let pts: Vec<[f64; 2]> = poly
+                        .iter()
+                        .map(|pt| {
+                            [
+                                pt[0] * cos_a - pt[1] * sin_a + pos[0],
+                                pt[0] * sin_a + pt[1] * cos_a + pos[1],
+                            ]
+                        })
+                        .collect();
+                    let d = format!("{}Z", svg::polyline_to_d(&pts));
                     if filled.is_none_or(|f| f != 0) {
                         write!(svg, r#"<path d="{d}" fill="{color}" fill-rule="evenodd"/>"#)
                             .unwrap();
                     } else {
-                        let sw = if *width < 0.1 { 0.1 } else { *width };
+                        let sw = svg::stroke_w(*width);
                         write!(
                             svg,
                             r#"<path d="{d}" fill="none" stroke="{color}" stroke-width="{sw:.4}"/>"#,
@@ -184,7 +181,7 @@ fn render_drawings(svg: &mut String, drawings: &[Drawing], color: &str) {
                 cpb,
                 width,
             } => {
-                let sw = if *width < 0.1 { 0.1 } else { *width };
+                let sw = svg::stroke_w(*width);
                 write!(
                     svg,
                     r#"<path d="M{:.4} {:.4}C{:.4} {:.4},{:.4} {:.4},{:.4} {:.4}" fill="none" stroke="{color}" stroke-width="{sw:.4}" stroke-linecap="round"/>"#,
@@ -226,7 +223,7 @@ fn render_arc(
     let large = if forward_sweep > 180.0 { 1 } else { 0 };
     let sweep_flag = 1;
 
-    let sw = if width < 0.1 { 0.1 } else { width };
+    let sw = svg::stroke_w(width);
     write!(
         svg,
         r#"<path d="M{x1:.4} {y1:.4}A{radius:.4} {radius:.4} 0 {large} {sweep_flag} {x2:.4} {y2:.4}" fill="none" stroke="{color}" stroke-width="{sw:.4}" stroke-linecap="round"/>"#,
@@ -284,7 +281,7 @@ fn render_tracks(svg: &mut String, tracks: &[crate::types::Track], color: &str) 
             crate::types::Track::Segment {
                 start, end, width, ..
             } => {
-                let sw = if *width < 0.1 { 0.1 } else { *width };
+                let sw = svg::stroke_w(*width);
                 write!(
                     svg,
                     r#"<line x1="{:.4}" y1="{:.4}" x2="{:.4}" y2="{:.4}" stroke="{color}" stroke-width="{sw:.4}" stroke-linecap="round" opacity="0.5"/>"#,
@@ -313,15 +310,7 @@ fn render_zones(svg: &mut String, zones: &[crate::types::Zone]) {
                 if poly.len() < 3 {
                     continue;
                 }
-                let mut d = String::new();
-                for (i, pt) in poly.iter().enumerate() {
-                    if i == 0 {
-                        write!(d, "M{:.4} {:.4}", pt[0], pt[1]).unwrap();
-                    } else {
-                        write!(d, "L{:.4} {:.4}", pt[0], pt[1]).unwrap();
-                    }
-                }
-                d.push('Z');
+                let d = format!("{}Z", svg::polyline_to_d(poly));
                 write!(
                     svg,
                     r#"<path d="{d}" fill="{PAD_COLOR}" opacity="0.3" fill-rule="evenodd"/>"#,


### PR DESCRIPTION
Milestone 2 of the GDSII tile viewer (docs/04-gdsii-tile-viewer.md).

Pure refactor: lifts the inline `d`-string / viewBox / stroke-clamp logic out of `thumbnail.rs` into a new `pcb_extract::svg` module — `polyline_to_d`, `poly_to_d`, `stroke_w`, `view_box` — and routes the thumbnail through them. Output is byte-identical (all thumbnail golden tests unchanged); the tile renderer (M5) will reuse the same helpers so the two SVG paths don't drift.