### PR TITLE
Add GDSII tile-set driver and manifest (stage 4)

### DIFF
--- a/crates/pcb-extract/src/parsers/gdsii.rs
+++ b/crates/pcb-extract/src/parsers/gdsii.rs
@@ -8,6 +8,7 @@ pub mod bsp;
 mod reader;
 pub mod tile;
 pub mod tiler;
+pub mod tileset;
 
 // Byte-level record reader (record framing, float decode, RecordData accessors).
 use reader::*;

--- a/crates/pcb-extract/src/parsers/gdsii/tileset.rs
+++ b/crates/pcb-extract/src/parsers/gdsii/tileset.rs
@@ -1,0 +1,440 @@
+//! GDSII tile pipeline — stage 4: tile-set driver + manifest.
+//!
+//! Ties the stream (stage 1), the BSP index (stage 2), and the renderer
+//! (stage 3) together: given a `.gds` byte buffer it produces a [`Manifest`],
+//! the serialized index, and the eager (zoomed-out) tile blobs. The server
+//! persists these and serves them; the WASM viewer reads the manifest first,
+//! then fetches tiles on demand.
+
+use std::collections::{BTreeMap, HashMap};
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::ExtractError;
+
+use super::bsp::BspIndex;
+use super::tile::{stream_records, PlacedRecord, WorldBox};
+use super::tiler::{
+    lod_partition, render_layer_tile, render_overlay, svgz, Pyramid, LOD_MIN_PX, TILE_PX,
+};
+
+/// Finest resolution the deepest pyramid level targets, in nm/px.
+const RES_MIN_NM_PER_PX: f64 = 1.0;
+
+// ─── Manifest (the viewer/tiler contract; served as JSON) ────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Manifest {
+    pub id: String,
+    pub units: Units,
+    pub extent_nm: Extent,
+    pub tile_px: u32,
+    pub zoom: Zoom,
+    pub lod_min_px: f64,
+    pub layers: Vec<LayerInfo>,
+    pub generated: Generated,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Units {
+    pub nm_per_world: f64,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct Extent {
+    pub minx: i64,
+    pub miny: i64,
+    pub maxx: i64,
+    pub maxy: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Zoom {
+    pub min: u32,
+    pub max: u32,
+    pub res_nm_per_px: Vec<f64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LayerInfo {
+    /// `"{layer}/{datatype}"`, or `"__lod"` for the synthetic overlay layer.
+    pub key: String,
+    pub layer: i16,
+    pub datatype: i16,
+    pub name: String,
+    pub count: u64,
+    pub bbox_nm: Extent,
+    pub default_color: String,
+    pub default_order: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Generated {
+    pub mode: String,
+    pub eager_max_z: u32,
+}
+
+/// The synthetic overlay layer key (its tiles carry "(n hidden)" annotations).
+pub const LOD_KEY: &str = "__lod";
+
+// ─── Driver output ───────────────────────────────────────────────────────────
+
+/// Everything to persist for one ingested GDSII file.
+pub struct TileSet {
+    pub manifest: Manifest,
+    /// Serialized [`BspIndex`] (cache so re-tiling needn't re-parse).
+    pub index_bytes: Vec<u8>,
+    /// Eager tile blobs: `(path under tiles/, gzipped-SVG body)`.
+    /// Path is `"{z}/{x}/{y}/{key}.svgz"`.
+    pub tiles: Vec<(String, Vec<u8>)>,
+}
+
+fn ext(b: &WorldBox) -> Extent {
+    Extent {
+        minx: b.minx,
+        miny: b.miny,
+        maxx: b.maxx,
+        maxy: b.maxy,
+    }
+}
+
+/// Deterministic per-layer color (no GDSII layer-map): hash the key into a
+/// small palette so the same layer always gets the same hue.
+fn palette_color(layer: i16, datatype: i16) -> String {
+    const PALETTE: [&str; 12] = [
+        "#7aa2f7", "#9ece6a", "#e0af68", "#bb9af7", "#7dcfff", "#f7768e", "#2ac3de", "#ff9e64",
+        "#73daca", "#b4f9f8", "#c0caf5", "#ff007c",
+    ];
+    let h = (layer as i64)
+        .wrapping_mul(31)
+        .wrapping_add(datatype as i64);
+    let idx = h.rem_euclid(PALETTE.len() as i64) as usize;
+    PALETTE[idx].to_string()
+}
+
+/// Build the tile set for a GDSII byte buffer. `eager_max_z` bounds how many
+/// zoomed-out levels are pre-rendered; deeper levels are generated on demand.
+pub fn build_tileset(id: &str, data: &[u8], eager_max_z: u32) -> Result<TileSet, ExtractError> {
+    let stream = stream_records(data)?;
+    let records = stream.records;
+
+    // Group by (layer, datatype) for per-layer counts and extents.
+    let mut groups: BTreeMap<(i16, i16), (u64, WorldBox)> = BTreeMap::new();
+    let mut bounds = WorldBox::empty();
+    for r in &records {
+        bounds.union(&r.bbox);
+        let e = groups
+            .entry((r.layer, r.datatype))
+            .or_insert((0, WorldBox::empty()));
+        e.0 += 1;
+        e.1.union(&r.bbox);
+    }
+    if bounds.is_empty() {
+        bounds = WorldBox {
+            minx: 0,
+            miny: 0,
+            maxx: 1,
+            maxy: 1,
+        };
+    }
+
+    let pyramid = Pyramid::new(bounds, RES_MIN_NM_PER_PX);
+    let max_z = pyramid.levels.saturating_sub(1);
+    let res_nm_per_px: Vec<f64> = (0..pyramid.levels).map(|z| pyramid.res(z)).collect();
+
+    let index = BspIndex::build(records);
+    let index_bytes = index
+        .to_bytes()
+        .map_err(|e| ExtractError::ParseError(format!("GDSII tile index serialize: {e}")))?;
+
+    // Manifest layers: one per (layer, datatype) plus the synthetic LOD overlay.
+    let mut layers = Vec::new();
+    for (order, (&(layer, datatype), &(count, bbox))) in groups.iter().enumerate() {
+        layers.push(LayerInfo {
+            key: format!("{layer}/{datatype}"),
+            layer,
+            datatype,
+            name: format!("L{layer}/{datatype}"),
+            count,
+            bbox_nm: ext(&bbox),
+            default_color: palette_color(layer, datatype),
+            default_order: order as u32,
+        });
+    }
+    layers.push(LayerInfo {
+        key: LOD_KEY.to_string(),
+        layer: 0,
+        datatype: 0,
+        name: "omitted (LOD)".to_string(),
+        count: 0,
+        bbox_nm: ext(&bounds),
+        default_color: "#f7768e".to_string(),
+        default_order: layers.len() as u32,
+    });
+
+    // Eager tiles for the zoomed-out levels.
+    let eager = eager_max_z.min(max_z);
+    let mut tiles = Vec::new();
+    for z in 0..=eager {
+        let n = pyramid.tiles_per_axis(z);
+        let res_z = pyramid.res(z);
+        for ty in 0..n {
+            for tx in 0..n {
+                let tbox = pyramid.tile_world_box(z, tx, ty);
+                if !tbox.intersects(&bounds) {
+                    continue;
+                }
+                let hits = index.query_records(&tbox);
+                if hits.is_empty() {
+                    continue;
+                }
+                let mut by_layer: HashMap<(i16, i16), Vec<&PlacedRecord>> = HashMap::new();
+                for r in hits {
+                    by_layer.entry((r.layer, r.datatype)).or_default().push(r);
+                }
+                let mut all_omitted: Vec<&PlacedRecord> = Vec::new();
+                for ((layer, datatype), recs) in &by_layer {
+                    let (kept, omitted) = lod_partition(recs, res_z);
+                    all_omitted.extend(omitted);
+                    if kept.is_empty() {
+                        continue;
+                    }
+                    let color = palette_color(*layer, *datatype);
+                    let svg = render_layer_tile(&kept, &tbox, &color);
+                    tiles.push((format!("{z}/{tx}/{ty}/{layer}_{datatype}.svgz"), svgz(&svg)));
+                }
+                if !all_omitted.is_empty() {
+                    let svg = render_overlay(&all_omitted, &tbox);
+                    tiles.push((format!("{z}/{tx}/{ty}/{LOD_KEY}.svgz"), svgz(&svg)));
+                }
+            }
+        }
+    }
+
+    let manifest = Manifest {
+        id: id.to_string(),
+        units: Units { nm_per_world: 1.0 },
+        extent_nm: ext(&bounds),
+        tile_px: TILE_PX,
+        zoom: Zoom {
+            min: 0,
+            max: max_z,
+            res_nm_per_px,
+        },
+        lod_min_px: LOD_MIN_PX,
+        layers,
+        generated: Generated {
+            mode: "eager".to_string(),
+            eager_max_z: eager,
+        },
+    };
+
+    Ok(TileSet {
+        manifest,
+        index_bytes,
+        tiles,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    // Minimal GDSII byte-stream builder (mirrors the tile-module tests).
+    fn frame(rt: u8, dt: u8, payload: &[u8]) -> Vec<u8> {
+        let len = (4 + payload.len()) as u16;
+        let mut v = Vec::new();
+        v.write_all(&len.to_be_bytes()).unwrap();
+        v.push(rt);
+        v.push(dt);
+        v.extend_from_slice(payload);
+        v
+    }
+    fn no_data(rt: u8) -> Vec<u8> {
+        frame(rt, 0x00, &[])
+    }
+    fn i16r(rt: u8, vals: &[i16]) -> Vec<u8> {
+        let mut p = Vec::new();
+        for &x in vals {
+            p.extend_from_slice(&x.to_be_bytes());
+        }
+        frame(rt, 0x02, &p)
+    }
+    fn i32r(rt: u8, vals: &[i32]) -> Vec<u8> {
+        let mut p = Vec::new();
+        for &x in vals {
+            p.extend_from_slice(&x.to_be_bytes());
+        }
+        frame(rt, 0x03, &p)
+    }
+    fn f64r(rt: u8, vals: &[f64]) -> Vec<u8> {
+        let mut p = Vec::new();
+        for &x in vals {
+            p.extend_from_slice(&f64_to_gds(x));
+        }
+        frame(rt, 0x05, &p)
+    }
+    fn ascii(rt: u8, s: &str) -> Vec<u8> {
+        let mut p = s.as_bytes().to_vec();
+        if p.len() % 2 == 1 {
+            p.push(0);
+        }
+        frame(rt, 0x06, &p)
+    }
+    fn f64_to_gds(value: f64) -> [u8; 8] {
+        if value == 0.0 {
+            return [0u8; 8];
+        }
+        let sign = if value < 0.0 { 1u8 } else { 0u8 };
+        let mut v = value.abs();
+        let mut exponent = 64i32;
+        while v >= 1.0 {
+            v /= 16.0;
+            exponent += 1;
+        }
+        while v < 1.0 / 16.0 {
+            v *= 16.0;
+            exponent -= 1;
+        }
+        let mantissa = (v * (1u64 << 56) as f64) as u64;
+        let mut b = [0u8; 8];
+        b[0] = (sign << 7) | (exponent as u8 & 0x7F);
+        for (i, byte) in b.iter_mut().enumerate().skip(1) {
+            *byte = ((mantissa >> (8 * (7 - i))) & 0xFF) as u8;
+        }
+        b
+    }
+
+    // record types
+    const HEADER: u8 = 0x00;
+    const BGNLIB: u8 = 0x01;
+    const LIBNAME: u8 = 0x02;
+    const UNITS: u8 = 0x03;
+    const ENDLIB: u8 = 0x04;
+    const BGNSTR: u8 = 0x05;
+    const STRNAME: u8 = 0x06;
+    const ENDSTR: u8 = 0x07;
+    const BOUNDARY: u8 = 0x08;
+    const LAYER: u8 = 0x0D;
+    const DATATYPE: u8 = 0x0E;
+    const XY: u8 = 0x10;
+    const ENDEL: u8 = 0x11;
+
+    fn square(layer: i16, dt: i16, x0: i32, y0: i32, side: i32) -> Vec<u8> {
+        let mut g = Vec::new();
+        g.extend(no_data(BOUNDARY));
+        g.extend(i16r(LAYER, &[layer]));
+        g.extend(i16r(DATATYPE, &[dt]));
+        g.extend(i32r(
+            XY,
+            &[
+                x0,
+                y0,
+                x0 + side,
+                y0,
+                x0 + side,
+                y0 + side,
+                x0,
+                y0 + side,
+                x0,
+                y0,
+            ],
+        ));
+        g.extend(no_data(ENDEL));
+        g
+    }
+
+    /// One cell, two layers (1/0 and 2/0), each a 1000nm square offset apart.
+    fn two_layer_file() -> Vec<u8> {
+        let mut g = Vec::new();
+        g.extend(i16r(HEADER, &[600]));
+        g.extend(i16r(BGNLIB, &[0; 12]));
+        g.extend(ascii(LIBNAME, "TOP"));
+        g.extend(f64r(UNITS, &[1e-3, 1e-9])); // 1 nm/DBU
+        g.extend(i16r(BGNSTR, &[0; 12]));
+        g.extend(ascii(STRNAME, "TOP"));
+        g.extend(square(1, 0, 0, 0, 1000));
+        g.extend(square(2, 0, 2000, 2000, 1000));
+        g.extend(no_data(ENDSTR));
+        g.extend(no_data(ENDLIB));
+        g
+    }
+
+    #[test]
+    fn manifest_has_layers_and_lod() {
+        let ts = build_tileset("abc", &two_layer_file(), 4).unwrap();
+        let keys: Vec<&str> = ts.manifest.layers.iter().map(|l| l.key.as_str()).collect();
+        assert!(keys.contains(&"1/0"));
+        assert!(keys.contains(&"2/0"));
+        assert!(keys.contains(&"__lod"));
+        assert_eq!(ts.manifest.id, "abc");
+        assert_eq!(ts.manifest.tile_px, TILE_PX);
+        // extent covers both squares: x 0..3000, y 0..3000
+        assert_eq!(ts.manifest.extent_nm.minx, 0);
+        assert_eq!(ts.manifest.extent_nm.maxx, 3000);
+        // one res entry per level
+        assert_eq!(
+            ts.manifest.zoom.res_nm_per_px.len() as u32,
+            ts.manifest.zoom.max + 1
+        );
+    }
+
+    #[test]
+    fn emits_level0_tiles_and_serializes_round_trip() {
+        let ts = build_tileset("abc", &two_layer_file(), 0).unwrap();
+        // At least one level-0 tile per real layer.
+        assert!(ts.tiles.iter().any(|(p, _)| p.starts_with("0/0/0/1_0")));
+        assert!(ts.tiles.iter().any(|(p, _)| p.starts_with("0/0/0/2_0")));
+        // tiles are gzip
+        for (_, body) in &ts.tiles {
+            assert!(body.len() >= 2 && body[0] == 0x1f && body[1] == 0x8b);
+        }
+        // index round-trips and answers a query over the full extent.
+        let idx = BspIndex::from_bytes(&ts.index_bytes).unwrap();
+        let all = idx.query(&WorldBox {
+            minx: 0,
+            miny: 0,
+            maxx: 3000,
+            maxy: 3000,
+        });
+        assert_eq!(all.len(), 2);
+    }
+
+    #[test]
+    fn manifest_serializes_to_expected_json_shape() {
+        let ts = build_tileset("abc", &two_layer_file(), 0).unwrap();
+        let json = serde_json::to_string(&ts.manifest).unwrap();
+        for field in [
+            "\"id\"",
+            "\"units\"",
+            "nm_per_world",
+            "extent_nm",
+            "tile_px",
+            "res_nm_per_px",
+            "lod_min_px",
+            "default_color",
+            "default_order",
+            "eager_max_z",
+        ] {
+            assert!(json.contains(field), "manifest JSON missing {field}");
+        }
+    }
+
+    #[test]
+    fn empty_design_does_not_panic() {
+        let mut g = Vec::new();
+        g.extend(i16r(HEADER, &[600]));
+        g.extend(i16r(BGNLIB, &[0; 12]));
+        g.extend(ascii(LIBNAME, "T"));
+        g.extend(f64r(UNITS, &[1e-3, 1e-9]));
+        g.extend(i16r(BGNSTR, &[0; 12]));
+        g.extend(ascii(STRNAME, "T"));
+        g.extend(no_data(ENDSTR));
+        g.extend(no_data(ENDLIB));
+        let ts = build_tileset("e", &g, 4).unwrap();
+        // only the synthetic __lod layer
+        assert_eq!(ts.manifest.layers.len(), 1);
+        assert!(ts.tiles.is_empty());
+    }
+}


### PR DESCRIPTION
Milestone 6 (library half) of the GDSII tile viewer (docs/04-gdsii-tile-viewer.md).

`parsers::gdsii::tileset::build_tileset(id, data, eager_max_z)` is the driver that ties stages 1–3 together: stream records → build the BSP index → render the eager tile pyramid. It returns a `TileSet { manifest, index_bytes, tiles }`:
- **Manifest** (`Manifest`/`LayerInfo`/...): the JSON contract the WASM viewer reads first — extent, tile_px, per-level res, per-(layer,datatype) layers with counts/bbox/color/order, plus the synthetic `__lod` overlay layer. Serde-serializable.
- **index_bytes**: the postcard-serialized `BspIndex` (cached so re-tiling needn't re-parse).
- **tiles**: eager `.svgz` blobs keyed `{z}/{x}/{y}/{layer}_{dt}.svgz` (and `__lod.svgz`), per-layer, LOD-culled.

Library only — the server `/upload` ingest + serving routes land in M7. Deterministic palette stands in for a GDSII layer map. Tests cover manifest shape, level-0 tile emission + gzip, index round-trip, and empty-design safety. Suite 255 green, clippy `-D warnings` clean.