### PR TITLE
Add GDSII WASM tile viewer (gds-viewer crate)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,11 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - run: cargo clippy --workspace --exclude pastebom-viewer -- -D warnings
+      - run: cargo clippy --workspace --exclude pastebom-viewer --exclude gds-viewer -- -D warnings
 
       - run: cargo clippy -p pastebom-viewer --target wasm32-unknown-unknown -- -D warnings
+
+      - run: cargo clippy -p gds-viewer --target wasm32-unknown-unknown -- -D warnings
 
   test:
     name: Tests
@@ -51,7 +53,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - run: cargo test --workspace --exclude pastebom-viewer
+      - run: cargo test --workspace --exclude pastebom-viewer --exclude gds-viewer
 
   container:
     name: Container Build

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ target/
 
 # WASM build output
 crates/viewer/dist/
+crates/gds-viewer/dist/
 
 # Reference specs (downloaded, not checked in)
 specs/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1400,6 +1400,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "gds-viewer"
+version = "1.9.0"
+dependencies = [
+ "gloo 0.11.0",
+ "js-sys",
+ "log",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-logger",
+ "web-sys",
+ "yew",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/pcb-extract", "crates/server", "crates/viewer"]
+members = ["crates/pcb-extract", "crates/server", "crates/viewer", "crates/gds-viewer"]
 resolver = "2"
 
 [workspace.package]

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,14 +21,16 @@ COPY Cargo.lock Cargo.lock
 COPY crates/pcb-extract/Cargo.toml crates/pcb-extract/Cargo.toml
 COPY crates/server/Cargo.toml crates/server/Cargo.toml
 COPY crates/viewer/Cargo.toml crates/viewer/Cargo.toml
+COPY crates/gds-viewer/Cargo.toml crates/gds-viewer/Cargo.toml
 
 # Create dummy source files for dependency caching
-RUN mkdir -p crates/pcb-extract/src crates/server/src crates/server/static crates/viewer/src \
+RUN mkdir -p crates/pcb-extract/src crates/server/src crates/server/static crates/viewer/src crates/gds-viewer/src \
     && echo "pub fn main() {}" > crates/pcb-extract/src/main.rs \
     && echo "pub fn lib() {}" > crates/pcb-extract/src/lib.rs \
     && echo "fn main() {}" > crates/server/src/main.rs \
     && echo "<html></html>" > crates/server/static/index.html \
-    && echo "fn main() {}" > crates/viewer/src/main.rs
+    && echo "fn main() {}" > crates/viewer/src/main.rs \
+    && echo "fn main() {}" > crates/gds-viewer/src/main.rs
 
 # Build dependencies only (cached layer)
 RUN cargo build --release --locked 2>/dev/null || true
@@ -40,13 +42,17 @@ COPY crates/ crates/
 RUN touch crates/pcb-extract/src/main.rs \
     crates/pcb-extract/src/lib.rs \
     crates/server/src/main.rs \
-    crates/viewer/src/main.rs
+    crates/viewer/src/main.rs \
+    crates/gds-viewer/src/main.rs
 
 # Build release binaries
 RUN cargo build --release --locked
 
 # Build viewer WASM
 RUN cd crates/viewer && trunk build --release
+
+# Build GDSII tile viewer WASM
+RUN cd crates/gds-viewer && trunk build --release
 
 # =============================================================================
 # Stage 2: Runtime
@@ -64,6 +70,7 @@ WORKDIR /app
 COPY --from=builder /build/target/release/pastebom-server /app/pastebom-server
 COPY --from=builder /build/target/release/pcb-extract /app/pcb-extract
 COPY --from=builder /build/crates/viewer/dist /app/viewer
+COPY --from=builder /build/crates/gds-viewer/dist /app/gview
 
 ENV BIND_ADDR=0.0.0.0:8080
 ENV VIEWER_DIR=/app/viewer

--- a/crates/gds-viewer/Cargo.toml
+++ b/crates/gds-viewer/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "gds-viewer"
+version.workspace = true
+edition = "2021"
+
+[dependencies]
+yew = { version = "0.21", features = ["csr"] }
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
+js-sys = "0.3"
+gloo = { version = "0.11", features = ["net", "events", "storage", "timers", "utils"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+log = { workspace = true }
+wasm-logger = "0.2"
+
+[dependencies.web-sys]
+version = "0.3"
+features = [
+    "Window",
+    "Document",
+    "Element",
+    "HtmlElement",
+    "HtmlInputElement",
+    "HtmlImageElement",
+    "CssStyleDeclaration",
+    "DomRect",
+    "MouseEvent",
+    "WheelEvent",
+    "PointerEvent",
+    "DragEvent",
+    "DataTransfer",
+    "KeyboardEvent",
+    "Storage",
+    "Node",
+    "NodeList",
+    "EventTarget",
+    "Performance",
+    "Location",
+]

--- a/crates/gds-viewer/Trunk.toml
+++ b/crates/gds-viewer/Trunk.toml
@@ -1,0 +1,4 @@
+[build]
+target = "index.html"
+dist = "dist"
+public_url = "/gview/"

--- a/crates/gds-viewer/index.html
+++ b/crates/gds-viewer/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>GDSII Tile Viewer</title>
+    <link data-trunk rel="css" href="style.css" />
+</head>
+<body>
+</body>
+</html>

--- a/crates/gds-viewer/src/main.rs
+++ b/crates/gds-viewer/src/main.rs
@@ -1,0 +1,631 @@
+mod manifest;
+mod state;
+mod transform;
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use wasm_bindgen::JsCast;
+use web_sys::{HtmlElement, HtmlInputElement};
+use yew::prelude::*;
+
+use manifest::{Layer, Manifest};
+use state::{init_view_state, storage_prefix, write_view_state, LayerState, ViewState};
+use transform::{Pyramid, Transform};
+
+fn main() {
+    wasm_logger::init(wasm_logger::Config::default());
+    yew::Renderer::<App>::new().render();
+}
+
+/// Parse the board id from a `/g/{id}` (optionally `/g/{id}/...`) path.
+fn id_from_path(pathname: &str) -> Option<String> {
+    let mut parts = pathname.trim_start_matches('/').split('/');
+    if parts.next()? != "g" {
+        return None;
+    }
+    let id = parts.next()?;
+    if id.is_empty() {
+        None
+    } else {
+        Some(id.to_string())
+    }
+}
+
+/// Imperative pan/zoom state held outside Yew so high-frequency pointer/wheel
+/// events mutate it without a re-render per event; we trigger redraws via a
+/// counter when the visible tile set may have changed.
+struct Interaction {
+    transform: Transform,
+    pointers: HashMap<i32, PointerState>,
+    view_w: f64,
+    view_h: f64,
+}
+
+struct PointerState {
+    last_x: f64,
+    last_y: f64,
+}
+
+#[function_component(App)]
+fn app() -> Html {
+    let manifest = use_state(|| None::<Rc<Manifest>>);
+    let pyramid = use_state(|| None::<Rc<Pyramid>>);
+    let view = use_state(|| None::<ViewState>);
+    let prefix = use_state(String::new);
+    let error = use_state(|| None::<String>);
+    // Bumped to force a re-render of the tile grid after pan/zoom.
+    let redraw = use_state(|| 0u64);
+    let interaction: UseStateHandle<Rc<RefCell<Interaction>>> = use_state(|| {
+        Rc::new(RefCell::new(Interaction {
+            transform: Transform::default(),
+            pointers: HashMap::new(),
+            view_w: 1.0,
+            view_h: 1.0,
+        }))
+    });
+    // Index of the layer row currently being dragged (HTML5 DnD reorder).
+    let drag_src: UseStateHandle<Option<usize>> = use_state(|| None);
+
+    // ── Fetch manifest once ─────────────────────────────────────────
+    {
+        let manifest = manifest.clone();
+        let pyramid = pyramid.clone();
+        let view = view.clone();
+        let prefix = prefix.clone();
+        let error = error.clone();
+        let interaction = interaction.clone();
+        let redraw = redraw.clone();
+        use_effect_with((), move |_| {
+            wasm_bindgen_futures::spawn_local(async move {
+                let window = web_sys::window().unwrap();
+                let pathname = window.location().pathname().unwrap_or_default();
+                let Some(id) = id_from_path(&pathname) else {
+                    error.set(Some("No board id in URL".to_string()));
+                    return;
+                };
+                let url = format!("/g/{}/manifest.json", id);
+                match gloo::net::http::Request::get(&url).send().await {
+                    Ok(resp) if resp.ok() => match resp.text().await {
+                        Ok(text) => match serde_json::from_str::<Manifest>(&text) {
+                            Ok(m) => {
+                                let pfx = storage_prefix(&m.id);
+                                let vs = init_view_state(&m, &pfx);
+                                interaction.borrow_mut().transform = vs.transform();
+                                let pyr = Pyramid::from_manifest(&m);
+                                prefix.set(pfx);
+                                view.set(Some(vs));
+                                pyramid.set(Some(Rc::new(pyr)));
+                                manifest.set(Some(Rc::new(m)));
+                                redraw.set(1);
+                            }
+                            Err(e) => error.set(Some(format!("Bad manifest: {}", e))),
+                        },
+                        Err(e) => error.set(Some(format!("Read error: {}", e))),
+                    },
+                    Ok(resp) => error.set(Some(format!("Manifest not found ({})", resp.status()))),
+                    Err(e) => error.set(Some(format!("Network error: {}", e))),
+                }
+            });
+            || ()
+        });
+    }
+
+    // ── Track viewport size ─────────────────────────────────────────
+    {
+        let interaction = interaction.clone();
+        let redraw = redraw.clone();
+        use_effect_with((), move |_| {
+            let update = {
+                let interaction = interaction.clone();
+                let redraw = redraw.clone();
+                move || {
+                    if let Some(el) = web_sys::window()
+                        .and_then(|w| w.document())
+                        .and_then(|d| d.get_element_by_id("gds-map"))
+                    {
+                        let el: HtmlElement = el.dyn_into().unwrap();
+                        let mut it = interaction.borrow_mut();
+                        it.view_w = el.client_width() as f64;
+                        it.view_h = el.client_height() as f64;
+                        drop(it);
+                        redraw.set(*redraw + 1);
+                    }
+                }
+            };
+            update();
+            let listener = gloo::events::EventListener::new(
+                &web_sys::window().unwrap(),
+                "resize",
+                move |_| update(),
+            );
+            move || drop(listener)
+        });
+    }
+
+    // ── Persist view state (debounced via redraw dependency) ────────
+    {
+        let view = view.clone();
+        let prefix = prefix.clone();
+        use_effect_with((*redraw, (*view).clone()), move |_| {
+            if let Some(ref vs) = *view {
+                if !prefix.is_empty() {
+                    write_view_state(vs, &prefix);
+                }
+            }
+            || ()
+        });
+    }
+
+    let Some(m) = (*manifest).clone() else {
+        let msg = (*error).clone().unwrap_or_else(|| "Loading…".to_string());
+        let class = if error.is_some() {
+            "gds-message error"
+        } else {
+            "gds-message"
+        };
+        return html! { <div id="app"><div id="gds-map" class="gds-map"><div class={class}>{msg}</div></div></div> };
+    };
+    let pyr = (*pyramid).clone().unwrap();
+    let vs = (*view).clone().unwrap();
+
+    // ── Event handlers ──────────────────────────────────────────────
+    let on_wheel = {
+        let interaction = interaction.clone();
+        let view = view.clone();
+        let redraw = redraw.clone();
+        Callback::from(move |e: WheelEvent| {
+            e.prevent_default();
+            let mut it = interaction.borrow_mut();
+            let mut delta = e.delta_y();
+            if e.delta_mode() == 1 {
+                delta *= 30.0;
+            } else if e.delta_mode() == 2 {
+                delta *= 300.0;
+            }
+            let mm = (1.1f64).powf(-delta / 40.0).clamp(0.5, 2.0);
+            it.transform.zoom *= mm;
+            // Cursor-centred: keep the point under the cursor fixed.
+            it.transform.panx =
+                e.offset_x() as f64 - (e.offset_x() as f64 - it.transform.panx) * mm;
+            it.transform.pany =
+                e.offset_y() as f64 - (e.offset_y() as f64 - it.transform.pany) * mm;
+            let t = it.transform;
+            drop(it);
+            persist_transform(&view, &t);
+            redraw.set(*redraw + 1);
+        })
+    };
+
+    let on_pointerdown = {
+        let interaction = interaction.clone();
+        Callback::from(move |e: PointerEvent| {
+            e.prevent_default();
+            if let Some(el) = e.target().and_then(|t| t.dyn_into::<HtmlElement>().ok()) {
+                let _ = el.set_pointer_capture(e.pointer_id());
+            }
+            interaction.borrow_mut().pointers.insert(
+                e.pointer_id(),
+                PointerState {
+                    last_x: e.offset_x() as f64,
+                    last_y: e.offset_y() as f64,
+                },
+            );
+        })
+    };
+
+    let on_pointermove = {
+        let interaction = interaction.clone();
+        let view = view.clone();
+        let redraw = redraw.clone();
+        Callback::from(move |e: PointerEvent| {
+            let mut it = interaction.borrow_mut();
+            if !it.pointers.contains_key(&e.pointer_id()) {
+                return;
+            }
+            e.prevent_default();
+            let count = it.pointers.len();
+            if count == 2 {
+                let other_id = *it
+                    .pointers
+                    .keys()
+                    .find(|&&id| id != e.pointer_id())
+                    .unwrap();
+                let (ox, oy) = {
+                    let o = &it.pointers[&other_id];
+                    (o.last_x, o.last_y)
+                };
+                let (cx, cy) = {
+                    let c = &it.pointers[&e.pointer_id()];
+                    (c.last_x, c.last_y)
+                };
+                let nx = e.offset_x() as f64;
+                let ny = e.offset_y() as f64;
+                let old_mid_x = (cx + ox) / 2.0;
+                let old_mid_y = (cy + oy) / 2.0;
+                let new_mid_x = (nx + ox) / 2.0;
+                let new_mid_y = (ny + oy) / 2.0;
+                let old_dist = ((cx - ox).powi(2) + (cy - oy).powi(2)).sqrt();
+                let new_dist = ((nx - ox).powi(2) + (ny - oy).powi(2)).sqrt();
+                it.transform.panx += new_mid_x - old_mid_x;
+                it.transform.pany += new_mid_y - old_mid_y;
+                if old_dist > 1.0 && new_dist > 1.0 {
+                    let scale = (new_dist / old_dist).clamp(0.5, 2.0);
+                    it.transform.zoom *= scale;
+                    it.transform.panx = new_mid_x - (new_mid_x - it.transform.panx) * scale;
+                    it.transform.pany = new_mid_y - (new_mid_y - it.transform.pany) * scale;
+                }
+                if let Some(p) = it.pointers.get_mut(&e.pointer_id()) {
+                    p.last_x = nx;
+                    p.last_y = ny;
+                }
+            } else if count == 1 {
+                let (dx, dy) = {
+                    let p = &it.pointers[&e.pointer_id()];
+                    (
+                        e.offset_x() as f64 - p.last_x,
+                        e.offset_y() as f64 - p.last_y,
+                    )
+                };
+                it.transform.panx += dx;
+                it.transform.pany += dy;
+                if let Some(p) = it.pointers.get_mut(&e.pointer_id()) {
+                    p.last_x = e.offset_x() as f64;
+                    p.last_y = e.offset_y() as f64;
+                }
+            }
+            let t = it.transform;
+            drop(it);
+            persist_transform(&view, &t);
+            redraw.set(*redraw + 1);
+        })
+    };
+
+    let on_pointerup = {
+        let interaction = interaction.clone();
+        let view = view.clone();
+        let redraw = redraw.clone();
+        Callback::from(move |e: PointerEvent| {
+            let mut it = interaction.borrow_mut();
+            if e.button() == 2 {
+                it.transform = Transform::default();
+                let t = it.transform;
+                it.pointers.remove(&e.pointer_id());
+                drop(it);
+                persist_transform(&view, &t);
+                redraw.set(*redraw + 1);
+                return;
+            }
+            it.pointers.remove(&e.pointer_id());
+        })
+    };
+
+    let on_pointercancel = {
+        let interaction = interaction.clone();
+        Callback::from(move |e: PointerEvent| {
+            interaction.borrow_mut().pointers.remove(&e.pointer_id());
+        })
+    };
+
+    let on_contextmenu = Callback::from(|e: MouseEvent| e.prevent_default());
+
+    // ── Compose layer surfaces ──────────────────────────────────────
+    let (panx, pany, zoom, view_w, view_h) = {
+        let it = interaction.borrow();
+        (
+            it.transform.panx,
+            it.transform.pany,
+            it.transform.zoom,
+            it.view_w,
+            it.view_h,
+        )
+    };
+    let z = pyr.level_for_zoom(zoom);
+    let frac = pyr.frac_scale(zoom, z);
+
+    let layer_lookup: HashMap<String, &Layer> =
+        m.layers.iter().map(|l| (l.tile_key(), l)).collect();
+
+    let surfaces: Html = vs
+        .layers
+        .iter()
+        .enumerate()
+        .filter(|(_, l)| l.visible)
+        .map(|(idx, l)| render_surface(&m.id, l, idx, &pyr, z, frac, panx, pany, view_w, view_h))
+        .collect();
+
+    // ── Layer panel ─────────────────────────────────────────────────
+    let panel = render_panel(&vs, &view, &layer_lookup, &redraw, &drag_src);
+
+    // Prefer the manifest's per-level resolution when present, else derive it.
+    let res = m
+        .zoom
+        .res_nm_per_px
+        .get(z as usize)
+        .copied()
+        .unwrap_or_else(|| pyr.res(z));
+    let status = format!(
+        "z {} · {:.0}×{:.0} nm · {:.3} nm/px · zoom {:.2}",
+        z, pyr.extent_w, pyr.extent_h, res, zoom
+    );
+
+    html! {
+        <div id="app">
+            <div
+                id="gds-map"
+                class="gds-map"
+                onwheel={on_wheel}
+                onpointerdown={on_pointerdown}
+                onpointermove={on_pointermove}
+                onpointerup={on_pointerup}
+                onpointercancel={on_pointercancel}
+                oncontextmenu={on_contextmenu}
+            >
+                { surfaces }
+                <div class="gds-status">{ status }</div>
+            </div>
+            { panel }
+        </div>
+    }
+}
+
+/// Persist the latest transform into the React-style state handle so it survives
+/// reloads. We mutate a clone and set it back; cheap relative to a tile render.
+fn persist_transform(view: &UseStateHandle<Option<ViewState>>, t: &Transform) {
+    if let Some(mut vs) = (**view).clone() {
+        vs.set_transform(t);
+        view.set(Some(vs));
+    }
+}
+
+/// Render one layer's surface div with its visible `<img>` tiles. Tiles that
+/// 404 are hidden via an onerror handler so missing tiles simply aren't drawn.
+#[allow(clippy::too_many_arguments)]
+fn render_surface(
+    id: &str,
+    layer: &LayerState,
+    z_index: usize,
+    pyr: &Pyramid,
+    z: u32,
+    frac: f64,
+    panx: f64,
+    pany: f64,
+    view_w: f64,
+    view_h: f64,
+) -> Html {
+    let tile_screen = pyr.tile_px * frac;
+    let range = pyr.visible_tiles(z, panx, pany, frac, view_w, view_h);
+
+    let style = format!(
+        "z-index:{}; opacity:{};",
+        z_index,
+        layer.opacity.clamp(0.0, 1.0)
+    );
+
+    let mut tiles: Vec<Html> = Vec::new();
+    // Prefetch one ring beyond the viewport for snappier panning.
+    let n = pyr.tiles_per_axis(z) as i64;
+    let gx0 = (range.x0 - 1).max(0);
+    let gy0 = (range.y0 - 1).max(0);
+    let gx1 = (range.x1 + 1).min(n - 1);
+    let gy1 = (range.y1 + 1).min(n - 1);
+    for ty in gy0..=gy1 {
+        for tx in gx0..=gx1 {
+            let left = panx + tx as f64 * tile_screen;
+            let top = pany + ty as f64 * tile_screen;
+            let src = format!("/g/{}/tiles/{}/{}/{}/{}.svgz", id, z, tx, ty, layer.key);
+            let tile_style = format!(
+                "left:{:.2}px; top:{:.2}px; width:{:.2}px; height:{:.2}px;",
+                left, top, tile_screen, tile_screen
+            );
+            let key = format!("{}:{}:{}:{}", z, tx, ty, layer.key);
+            let onerror = Callback::from(|e: Event| {
+                if let Some(img) = e.target().and_then(|t| t.dyn_into::<HtmlElement>().ok()) {
+                    let _ = img.style().set_property("visibility", "hidden");
+                }
+            });
+            tiles.push(html! {
+                <img
+                    key={key}
+                    class="gds-tile"
+                    src={src}
+                    style={tile_style}
+                    {onerror}
+                    draggable="false"
+                />
+            });
+        }
+    }
+
+    html! {
+        <div class="gds-surface" style={style}>
+            { tiles }
+        </div>
+    }
+}
+
+fn render_panel(
+    vs: &ViewState,
+    view: &UseStateHandle<Option<ViewState>>,
+    lookup: &HashMap<String, &Layer>,
+    redraw: &UseStateHandle<u64>,
+    drag_src: &UseStateHandle<Option<usize>>,
+) -> Html {
+    let rows: Html = vs
+        .layers
+        .iter()
+        .enumerate()
+        .map(|(i, l)| {
+            let display = if l.name.is_empty() {
+                lookup
+                    .get(&l.key)
+                    .map(|m| m.display_name())
+                    .unwrap_or_else(|| l.key.clone())
+            } else {
+                l.name.clone()
+            };
+            let count = lookup.get(&l.key).map(|m| m.count).unwrap_or(0);
+
+            let on_toggle = layer_mutator(view, redraw, i, |ls| ls.visible = !ls.visible);
+            let on_color = {
+                let view = view.clone();
+                let redraw = redraw.clone();
+                Callback::from(move |e: Event| {
+                    if let Some(inp) = e
+                        .target()
+                        .and_then(|t| t.dyn_into::<HtmlInputElement>().ok())
+                    {
+                        let val = inp.value();
+                        mutate_layer(&view, &redraw, i, |ls| ls.color = val.clone());
+                    }
+                })
+            };
+            let on_name = {
+                let view = view.clone();
+                let redraw = redraw.clone();
+                Callback::from(move |e: InputEvent| {
+                    if let Some(inp) = e
+                        .target()
+                        .and_then(|t| t.dyn_into::<HtmlInputElement>().ok())
+                    {
+                        let val = inp.value();
+                        mutate_layer(&view, &redraw, i, |ls| ls.name = val.clone());
+                    }
+                })
+            };
+            let on_opacity = {
+                let view = view.clone();
+                let redraw = redraw.clone();
+                Callback::from(move |e: InputEvent| {
+                    if let Some(inp) = e
+                        .target()
+                        .and_then(|t| t.dyn_into::<HtmlInputElement>().ok())
+                    {
+                        if let Ok(v) = inp.value().parse::<f64>() {
+                            mutate_layer(&view, &redraw, i, |ls| ls.opacity = v / 100.0);
+                        }
+                    }
+                })
+            };
+
+            let ondragstart = {
+                let drag_src = drag_src.clone();
+                Callback::from(move |_: DragEvent| drag_src.set(Some(i)))
+            };
+            let ondragover = Callback::from(|e: DragEvent| e.prevent_default());
+            let ondrop = {
+                let drag_src = drag_src.clone();
+                let view = view.clone();
+                let redraw = redraw.clone();
+                Callback::from(move |e: DragEvent| {
+                    e.prevent_default();
+                    if let Some(from) = *drag_src {
+                        reorder_layer(&view, &redraw, from, i);
+                    }
+                    drag_src.set(None);
+                })
+            };
+
+            html! {
+                <div class="gds-row" draggable="true" {ondragstart} {ondragover} {ondrop}>
+                    <span class="gds-handle">{ "≡" }</span>
+                    <input
+                        type="checkbox"
+                        checked={l.visible}
+                        onchange={on_toggle}
+                    />
+                    <input
+                        type="color"
+                        class="gds-swatch"
+                        value={l.color.clone()}
+                        onchange={on_color}
+                    />
+                    <input
+                        type="text"
+                        class="gds-name"
+                        value={display}
+                        oninput={on_name}
+                    />
+                    <span class="gds-count">{ format_count(count) }</span>
+                    <input
+                        type="range"
+                        class="gds-opacity"
+                        min="0"
+                        max="100"
+                        value={((l.opacity * 100.0).round() as i64).to_string()}
+                        oninput={on_opacity}
+                    />
+                </div>
+            }
+        })
+        .collect();
+
+    html! {
+        <div class="gds-panel">
+            <h1>{ "Layers" }</h1>
+            { rows }
+        </div>
+    }
+}
+
+/// Build an onchange callback that mutates layer `i` in place.
+fn layer_mutator<F: Fn(&mut LayerState) + 'static>(
+    view: &UseStateHandle<Option<ViewState>>,
+    redraw: &UseStateHandle<u64>,
+    i: usize,
+    f: F,
+) -> Callback<Event> {
+    let view = view.clone();
+    let redraw = redraw.clone();
+    Callback::from(move |_: Event| {
+        mutate_layer(&view, &redraw, i, &f);
+    })
+}
+
+fn mutate_layer<F: Fn(&mut LayerState)>(
+    view: &UseStateHandle<Option<ViewState>>,
+    redraw: &UseStateHandle<u64>,
+    i: usize,
+    f: F,
+) {
+    if let Some(mut vs) = (**view).clone() {
+        if let Some(ls) = vs.layers.get_mut(i) {
+            f(ls);
+            view.set(Some(vs));
+            redraw.set(**redraw + 1);
+        }
+    }
+}
+
+fn reorder_layer(
+    view: &UseStateHandle<Option<ViewState>>,
+    redraw: &UseStateHandle<u64>,
+    from: usize,
+    to: usize,
+) {
+    if from == to {
+        return;
+    }
+    if let Some(mut vs) = (**view).clone() {
+        if from < vs.layers.len() && to < vs.layers.len() {
+            let item = vs.layers.remove(from);
+            vs.layers.insert(to, item);
+            view.set(Some(vs));
+            redraw.set(**redraw + 1);
+        }
+    }
+}
+
+fn format_count(n: u64) -> String {
+    let s = n.to_string();
+    let mut out = String::new();
+    let bytes = s.as_bytes();
+    for (i, c) in bytes.iter().enumerate() {
+        if i > 0 && (bytes.len() - i).is_multiple_of(3) {
+            out.push(',');
+        }
+        out.push(*c as char);
+    }
+    out
+}

--- a/crates/gds-viewer/src/manifest.rs
+++ b/crates/gds-viewer/src/manifest.rs
@@ -1,0 +1,177 @@
+//! Manifest contract consumed from `GET /g/{id}/manifest.json`.
+//!
+//! The server side is built in parallel against the same spec, so every field
+//! is optional-tolerant: missing pieces fall back to sane defaults rather than
+//! failing the whole fetch.
+
+use serde::Deserialize;
+
+/// Synthetic layer key for the level-of-detail overlay.
+pub const LOD_KEY: &str = "__lod";
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct Manifest {
+    pub id: String,
+    // Parsed for contract completeness; tile geometry is already world-space.
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub units: Units,
+    pub extent_nm: Extent,
+    #[serde(default = "default_tile_px")]
+    pub tile_px: u32,
+    pub zoom: Zoom,
+    // Retained from the manifest contract; the LOD overlay is a normal toggleable
+    // layer in the viewer, so this server-side threshold is informational here.
+    #[serde(default = "default_lod_min_px")]
+    #[allow(dead_code)]
+    pub lod_min_px: f64,
+    #[serde(default)]
+    pub layers: Vec<Layer>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct Units {
+    // World unit = nm by default; tile geometry is already in world units, so
+    // this scale is retained for completeness rather than applied client-side.
+    #[serde(default = "default_nm_per_world")]
+    #[allow(dead_code)]
+    pub nm_per_world: f64,
+}
+
+impl Default for Units {
+    fn default() -> Self {
+        Self {
+            nm_per_world: default_nm_per_world(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize)]
+pub struct Extent {
+    pub minx: f64,
+    pub miny: f64,
+    pub maxx: f64,
+    pub maxy: f64,
+}
+
+impl Extent {
+    pub fn width(&self) -> f64 {
+        (self.maxx - self.minx).max(1.0)
+    }
+
+    pub fn height(&self) -> f64 {
+        (self.maxy - self.miny).max(1.0)
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct Zoom {
+    pub min: u32,
+    pub max: u32,
+    #[serde(default)]
+    pub res_nm_per_px: Vec<f64>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct Layer {
+    pub key: String,
+    #[serde(default)]
+    pub layer: i64,
+    #[serde(default)]
+    pub datatype: i64,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub count: u64,
+    // Per-layer extent from the contract; reserved for a future "zoom to layer".
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub bbox_nm: Option<Extent>,
+    #[serde(default)]
+    pub default_color: Option<String>,
+    #[serde(default)]
+    pub default_order: Option<i64>,
+}
+
+impl Layer {
+    /// True for the synthetic level-of-detail overlay layer.
+    pub fn is_lod(&self) -> bool {
+        self.key == LOD_KEY
+    }
+
+    /// Tile-URL key: `"{layer}_{datatype}"` for real layers, `"__lod"` for the
+    /// overlay. The manifest's `key` uses a slash (`"10/0"`) for display.
+    pub fn tile_key(&self) -> String {
+        if self.is_lod() {
+            LOD_KEY.to_string()
+        } else {
+            format!("{}_{}", self.layer, self.datatype)
+        }
+    }
+
+    /// Display name: manifest name if present, else `L{layer}/{datatype}`.
+    pub fn display_name(&self) -> String {
+        if let Some(ref n) = self.name {
+            if !n.is_empty() {
+                return n.clone();
+            }
+        }
+        if self.is_lod() {
+            "omitted (LOD)".to_string()
+        } else {
+            format!("L{}/{}", self.layer, self.datatype)
+        }
+    }
+
+    /// Color: manifest default if present, else a deterministic palette colour
+    /// derived from the key's hash.
+    pub fn default_color(&self) -> String {
+        if let Some(ref c) = self.default_color {
+            if !c.is_empty() {
+                return c.clone();
+            }
+        }
+        palette_color(&self.key)
+    }
+}
+
+fn default_tile_px() -> u32 {
+    512
+}
+
+fn default_lod_min_px() -> f64 {
+    2.0
+}
+
+fn default_nm_per_world() -> f64 {
+    1.0
+}
+
+/// Deterministic palette: hash the layer key into a hue, fixed S/L.
+pub fn palette_color(key: &str) -> String {
+    // FNV-1a over the key bytes gives a stable, well-spread hash.
+    let mut h: u64 = 0xcbf29ce484222325;
+    for b in key.bytes() {
+        h ^= b as u64;
+        h = h.wrapping_mul(0x100000001b3);
+    }
+    let hue = (h % 360) as f64;
+    hsl_to_hex(hue, 0.62, 0.62)
+}
+
+fn hsl_to_hex(h: f64, s: f64, l: f64) -> String {
+    let c = (1.0 - (2.0 * l - 1.0).abs()) * s;
+    let hp = h / 60.0;
+    let x = c * (1.0 - (hp % 2.0 - 1.0).abs());
+    let (r1, g1, b1) = match hp as u32 {
+        0 => (c, x, 0.0),
+        1 => (x, c, 0.0),
+        2 => (0.0, c, x),
+        3 => (0.0, x, c),
+        4 => (x, 0.0, c),
+        _ => (c, 0.0, x),
+    };
+    let m = l - c / 2.0;
+    let to_byte = |v: f64| ((v + m) * 255.0).round().clamp(0.0, 255.0) as u8;
+    format!("#{:02x}{:02x}{:02x}", to_byte(r1), to_byte(g1), to_byte(b1))
+}

--- a/crates/gds-viewer/src/state.rs
+++ b/crates/gds-viewer/src/state.rs
@@ -1,0 +1,133 @@
+//! Per-design persistence in localStorage, mirroring the PCB viewer's
+//! `read_storage`/`write_storage`/`init_*` pattern under a `gds:{id}:` prefix.
+
+use serde::{Deserialize, Serialize};
+
+use crate::manifest::Manifest;
+use crate::transform::Transform;
+
+/// Editable, persisted state for one layer surface.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct LayerState {
+    /// Tile-URL key (`"{layer}_{datatype}"` or `"__lod"`).
+    pub key: String,
+    pub visible: bool,
+    pub color: String,
+    pub opacity: f64,
+    /// User name override; falls back to the manifest/derived name when empty.
+    #[serde(default)]
+    pub name: String,
+}
+
+/// Whole-design persisted settings.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ViewState {
+    /// Layers in user z-order (front of the vec = bottom of the stack).
+    pub layers: Vec<LayerState>,
+    pub panx: f64,
+    pub pany: f64,
+    pub zoom: f64,
+}
+
+impl ViewState {
+    /// Build default state from the manifest, ordered by `default_order` then key.
+    pub fn from_manifest(m: &Manifest) -> Self {
+        let mut layers: Vec<(i64, LayerState)> = m
+            .layers
+            .iter()
+            .enumerate()
+            .map(|(i, l)| {
+                let order = l.default_order.unwrap_or(i as i64);
+                (
+                    order,
+                    LayerState {
+                        key: l.tile_key(),
+                        visible: true,
+                        color: l.default_color(),
+                        opacity: 1.0,
+                        name: String::new(),
+                    },
+                )
+            })
+            .collect();
+        layers.sort_by_key(|(o, _)| *o);
+        Self {
+            layers: layers.into_iter().map(|(_, l)| l).collect(),
+            panx: 0.0,
+            pany: 0.0,
+            zoom: 1.0,
+        }
+    }
+
+    pub fn transform(&self) -> Transform {
+        Transform {
+            panx: self.panx,
+            pany: self.pany,
+            zoom: self.zoom,
+        }
+    }
+
+    pub fn set_transform(&mut self, t: &Transform) {
+        self.panx = t.panx;
+        self.pany = t.pany;
+        self.zoom = t.zoom;
+    }
+}
+
+pub fn storage_prefix(id: &str) -> String {
+    format!("gds:{}:", id)
+}
+
+pub fn read_storage(key: &str, prefix: &str) -> Option<String> {
+    let window = web_sys::window()?;
+    let storage = window.local_storage().ok()??;
+    storage.get_item(&format!("{}{}", prefix, key)).ok()?
+}
+
+pub fn write_storage(key: &str, value: &str, prefix: &str) {
+    if let Some(window) = web_sys::window() {
+        if let Ok(Some(storage)) = window.local_storage() {
+            let _ = storage.set_item(&format!("{}{}", prefix, key), value);
+        }
+    }
+}
+
+/// Load persisted state for a design, falling back to manifest defaults.
+///
+/// Persisted layers are merged against the manifest by key: any new layers in
+/// the manifest are appended, and any persisted layers no longer present are
+/// dropped, so a re-tile with different layers stays consistent.
+pub fn init_view_state(m: &Manifest, prefix: &str) -> ViewState {
+    let defaults = ViewState::from_manifest(m);
+    let Some(raw) = read_storage("view", prefix) else {
+        return defaults;
+    };
+    let Ok(stored) = serde_json::from_str::<ViewState>(&raw) else {
+        return defaults;
+    };
+
+    let valid_keys: Vec<String> = defaults.layers.iter().map(|l| l.key.clone()).collect();
+    let mut merged: Vec<LayerState> = stored
+        .layers
+        .into_iter()
+        .filter(|l| valid_keys.contains(&l.key))
+        .collect();
+    for d in &defaults.layers {
+        if !merged.iter().any(|l| l.key == d.key) {
+            merged.push(d.clone());
+        }
+    }
+
+    ViewState {
+        layers: merged,
+        panx: stored.panx,
+        pany: stored.pany,
+        zoom: if stored.zoom > 0.0 { stored.zoom } else { 1.0 },
+    }
+}
+
+pub fn write_view_state(state: &ViewState, prefix: &str) {
+    if let Ok(s) = serde_json::to_string(state) {
+        write_storage("view", &s, prefix);
+    }
+}

--- a/crates/gds-viewer/src/transform.rs
+++ b/crates/gds-viewer/src/transform.rs
@@ -1,0 +1,142 @@
+//! Pan/zoom transform and slippy-map pyramid geometry.
+//!
+//! `Transform` mirrors the PCB viewer's pan/zoom state (`panx`/`pany`/`zoom`),
+//! reusing the same cursor-centred wheel and pointer math. On top of it we map
+//! a continuous `zoom` onto a discrete tile level plus a fractional CSS scale.
+
+use crate::manifest::Manifest;
+
+/// Continuous pan/zoom state, in CSS pixels at the base (level-0) scale.
+///
+/// `panx`/`pany` translate the world surface; `zoom` is the continuous scale.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Transform {
+    pub panx: f64,
+    pub pany: f64,
+    pub zoom: f64,
+}
+
+impl Default for Transform {
+    fn default() -> Self {
+        Self {
+            panx: 0.0,
+            pany: 0.0,
+            zoom: 1.0,
+        }
+    }
+}
+
+/// Pyramid geometry derived once from the manifest.
+#[derive(Clone, Debug)]
+pub struct Pyramid {
+    pub tile_px: f64,
+    /// Square world span (nm) covered by the whole design at level 0.
+    pub world_span: f64,
+    pub min_z: u32,
+    pub max_z: u32,
+    pub extent_w: f64,
+    pub extent_h: f64,
+}
+
+impl Pyramid {
+    pub fn from_manifest(m: &Manifest) -> Self {
+        let w = m.extent_nm.width();
+        let h = m.extent_nm.height();
+        // Level 0 fits the whole design in a single tile: the world edge is the
+        // next power of two above max(W, H) so deeper levels bisect cleanly.
+        let world_span = ceil_pow2(w.max(h));
+        Self {
+            tile_px: m.tile_px.max(1) as f64,
+            world_span,
+            min_z: m.zoom.min,
+            max_z: m.zoom.max.max(m.zoom.min),
+            extent_w: w,
+            extent_h: h,
+        }
+    }
+
+    /// World units per pixel at level `z`.
+    pub fn res(&self, z: u32) -> f64 {
+        self.span(z) / self.tile_px
+    }
+
+    /// World units along one tile edge at level `z`.
+    pub fn span(&self, z: u32) -> f64 {
+        self.world_span / (1u64 << z) as f64
+    }
+
+    /// Number of tiles per axis at level `z`.
+    pub fn tiles_per_axis(&self, z: u32) -> u32 {
+        1u32 << z
+    }
+
+    /// Map a continuous zoom (CSS scale relative to level-0 fit) to a discrete
+    /// tile level. `base` aligns zoom == 1.0 to the level whose resolution shows
+    /// the whole design at the viewport's base scale.
+    pub fn level_for_zoom(&self, zoom: f64) -> u32 {
+        let z = (zoom.max(1e-6).log2().round() as i64) + self.min_z as i64;
+        z.clamp(self.min_z as i64, self.max_z as i64) as u32
+    }
+
+    /// Fractional CSS scale to apply on top of the chosen level so continuous
+    /// zoom stays smooth between discrete levels.
+    pub fn frac_scale(&self, zoom: f64, z: u32) -> f64 {
+        // The chosen level covers 2^(z - min_z) of the level-0 fit.
+        let level_zoom = 2f64.powi((z as i32) - (self.min_z as i32));
+        (zoom / level_zoom).max(1e-6)
+    }
+}
+
+/// Round `v` up to the nearest power of two (as an f64 world span).
+fn ceil_pow2(v: f64) -> f64 {
+    if v <= 1.0 {
+        return 1.0;
+    }
+    2f64.powf(v.log2().ceil())
+}
+
+/// Inclusive tile (x, y) range covering a viewport, given level `z`.
+pub struct TileRange {
+    pub x0: i64,
+    pub y0: i64,
+    pub x1: i64,
+    pub y1: i64,
+}
+
+impl Pyramid {
+    /// Compute the visible tile range for a viewport.
+    ///
+    /// `panx`/`pany`/`scale` describe the CSS placement of the level-0 surface:
+    /// world point (0,0) of the surface maps to screen (panx, pany) and one
+    /// world tile edge at level `z` maps to `tile_px * scale` screen pixels.
+    pub fn visible_tiles(
+        &self,
+        z: u32,
+        panx: f64,
+        pany: f64,
+        scale: f64,
+        view_w: f64,
+        view_h: f64,
+    ) -> TileRange {
+        let tile_screen = self.tile_px * scale;
+        if tile_screen <= 0.0 {
+            return TileRange {
+                x0: 0,
+                y0: 0,
+                x1: 0,
+                y1: 0,
+            };
+        }
+        let n = self.tiles_per_axis(z) as i64;
+        let x0 = ((-panx) / tile_screen).floor() as i64;
+        let y0 = ((-pany) / tile_screen).floor() as i64;
+        let x1 = ((view_w - panx) / tile_screen).floor() as i64;
+        let y1 = ((view_h - pany) / tile_screen).floor() as i64;
+        TileRange {
+            x0: x0.clamp(0, n - 1),
+            y0: y0.clamp(0, n - 1),
+            x1: x1.clamp(0, n - 1),
+            y1: y1.clamp(0, n - 1),
+        }
+    }
+}

--- a/crates/gds-viewer/style.css
+++ b/crates/gds-viewer/style.css
@@ -1,0 +1,163 @@
+:root {
+    --bg: #16161e;
+    --panel-bg: #1a1b26;
+    --panel-border: #2a2b3c;
+    --text: #c0caf5;
+    --text-dim: #565f89;
+    --accent: #7aa2f7;
+    --row-hover: #232433;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+html,
+body {
+    margin: 0;
+    padding: 0;
+    height: 100%;
+    width: 100%;
+    overflow: hidden;
+    background: var(--bg);
+    color: var(--text);
+    font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    font-size: 13px;
+}
+
+#app {
+    display: flex;
+    height: 100vh;
+    width: 100vw;
+}
+
+.gds-map {
+    position: relative;
+    flex: 1 1 auto;
+    overflow: hidden;
+    background: var(--bg);
+    cursor: grab;
+    touch-action: none;
+}
+
+.gds-map:active {
+    cursor: grabbing;
+}
+
+.gds-surface {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 0;
+    height: 0;
+    transform-origin: 0 0;
+    pointer-events: none;
+}
+
+.gds-tile {
+    position: absolute;
+    image-rendering: auto;
+    pointer-events: none;
+    user-select: none;
+}
+
+.gds-panel {
+    flex: 0 0 320px;
+    background: var(--panel-bg);
+    border-left: 1px solid var(--panel-border);
+    overflow-y: auto;
+    padding: 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.gds-panel h1 {
+    font-size: 14px;
+    margin: 4px 6px 8px;
+    font-weight: 600;
+}
+
+.gds-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 6px;
+    border-radius: 4px;
+    border: 1px solid transparent;
+}
+
+.gds-row:hover {
+    background: var(--row-hover);
+}
+
+.gds-row.drag-over {
+    border-color: var(--accent);
+}
+
+.gds-handle {
+    cursor: grab;
+    color: var(--text-dim);
+    user-select: none;
+    flex: 0 0 auto;
+}
+
+.gds-swatch {
+    flex: 0 0 auto;
+    width: 18px;
+    height: 18px;
+    padding: 0;
+    border: 1px solid var(--panel-border);
+    border-radius: 3px;
+    background: none;
+    cursor: pointer;
+}
+
+.gds-name {
+    flex: 1 1 auto;
+    min-width: 0;
+    background: transparent;
+    border: none;
+    color: var(--text);
+    font-size: 13px;
+    padding: 2px;
+}
+
+.gds-name:focus {
+    outline: 1px solid var(--accent);
+    border-radius: 2px;
+}
+
+.gds-count {
+    flex: 0 0 auto;
+    color: var(--text-dim);
+    font-size: 11px;
+    font-variant-numeric: tabular-nums;
+}
+
+.gds-opacity {
+    flex: 0 0 70px;
+}
+
+.gds-status {
+    position: absolute;
+    bottom: 8px;
+    left: 8px;
+    background: rgba(26, 27, 38, 0.85);
+    border: 1px solid var(--panel-border);
+    border-radius: 4px;
+    padding: 4px 8px;
+    font-size: 11px;
+    color: var(--text-dim);
+    pointer-events: none;
+}
+
+.gds-message {
+    margin: auto;
+    text-align: center;
+    color: var(--text-dim);
+}
+
+.gds-message.error {
+    color: #f7768e;
+}


### PR DESCRIPTION
Implements **Milestones 8 + 9** of the GDSII tile viewer (`docs/04-gdsii-tile-viewer.md`): the WASM slippy-map compositor and its layer panel.

## What this is

A new, standalone Yew/WASM crate `crates/gds-viewer` — a second wasm app, separate from the PCB BOM viewer (`crates/viewer`). It shares no Rust code with the rest of the workspace and talks to the server only over HTTP.

## Contract consumed

- `GET /g/{id}/manifest.json` — design extent, pyramid zoom geometry, and the layer list (deserialized with tolerant defaults).
- `GET /g/{id}/tiles/{z}/{x}/{y}/{key}.svgz` — one tile per layer, `key` = `"{layer}_{datatype}"` or `"__lod"`. Served gzipped; the browser decompresses via `Content-Encoding: gzip`, so a plain `<img src=...>` works. Tiles that 404 are simply not drawn.

Pyramid geometry matches the spec: level 0 fits the whole design in one `tile_px` tile; level z has 2^z tiles per axis; rows grow downward.

## M8 — compositor

- One absolutely-positioned surface `<div>` per visible layer, ordered by the user's layer order, holding the viewport's `<img>` tiles positioned by CSS.
- Visible tile range computed from viewport + level, with a one-tile prefetch ring; missing tiles hidden via `onerror`.
- Cursor-centred wheel zoom (`m = 1.1^(-Δ/40)` with pan compensation), single-pointer pan, two-pointer pinch-zoom, right-click reset — mirroring `crates/viewer/src/render.rs`.
- Continuous zoom mapped to a discrete tile level plus a fractional CSS scale between levels.

## M9 — layer panel + persistence

- Draggable layer list (HTML5 DnD): drag handle, visibility checkbox, editable colour swatch, editable name, count, opacity slider. Reorder rewrites z-index/DOM order live (no refetch). The `__lod` overlay is a normal toggleable layer (default on).
- Layer naming/colour: manifest `name`/`default_color` if present, else `L{layer}/{datatype}` and a deterministic hue-from-key palette.
- Per-design `localStorage` persistence under `gds:{id}:` (order, per-layer visibility/colour/opacity/name, last transform), merged against the manifest by key.

## Infra

- Registered as a workspace member; CI lints it with its own wasm clippy line and excludes it from the host-target workspace clippy/test runs (it's wasm-only).
- Dockerfile builds its dist with trunk and ships it at `/app/gview`; the server route to serve the shell is being added separately.

## Verification

- `cargo fmt` clean.
- `cargo clippy -p gds-viewer --target wasm32-unknown-unknown -- -D warnings` — clean (the CI gate).
- `cargo build -p gds-viewer --target wasm32-unknown-unknown` — compiles.

`trunk` is not installed in this environment, so the Trunk build itself was not run locally; it is exercised by CI/Docker. A WASM UI cannot be runtime-tested here — this PR is compile/clippy-verified.