### PR TITLE
Wire GDSII upload ingest and tile-serving routes

### DIFF
--- a/crates/pcb-extract/src/parsers/gdsii/tileset.rs
+++ b/crates/pcb-extract/src/parsers/gdsii/tileset.rs
@@ -177,36 +177,9 @@ pub fn build_tileset(id: &str, data: &[u8], eager_max_z: u32) -> Result<TileSet,
     let mut tiles = Vec::new();
     for z in 0..=eager {
         let n = pyramid.tiles_per_axis(z);
-        let res_z = pyramid.res(z);
         for ty in 0..n {
             for tx in 0..n {
-                let tbox = pyramid.tile_world_box(z, tx, ty);
-                if !tbox.intersects(&bounds) {
-                    continue;
-                }
-                let hits = index.query_records(&tbox);
-                if hits.is_empty() {
-                    continue;
-                }
-                let mut by_layer: HashMap<(i16, i16), Vec<&PlacedRecord>> = HashMap::new();
-                for r in hits {
-                    by_layer.entry((r.layer, r.datatype)).or_default().push(r);
-                }
-                let mut all_omitted: Vec<&PlacedRecord> = Vec::new();
-                for ((layer, datatype), recs) in &by_layer {
-                    let (kept, omitted) = lod_partition(recs, res_z);
-                    all_omitted.extend(omitted);
-                    if kept.is_empty() {
-                        continue;
-                    }
-                    let color = palette_color(*layer, *datatype);
-                    let svg = render_layer_tile(&kept, &tbox, &color);
-                    tiles.push((format!("{z}/{tx}/{ty}/{layer}_{datatype}.svgz"), svgz(&svg)));
-                }
-                if !all_omitted.is_empty() {
-                    let svg = render_overlay(&all_omitted, &tbox);
-                    tiles.push((format!("{z}/{tx}/{ty}/{LOD_KEY}.svgz"), svgz(&svg)));
-                }
+                tiles.extend(render_tile_inner(&pyramid, &bounds, &index, z, tx, ty));
             }
         }
     }
@@ -234,6 +207,62 @@ pub fn build_tileset(id: &str, data: &[u8], eager_max_z: u32) -> Result<TileSet,
         index_bytes,
         tiles,
     })
+}
+
+/// Render every layer's blob for a single tile `(z, x, y)` on demand, given the
+/// design `bounds` (from the manifest) and the cached index. Returns
+/// `(path, svgz)` pairs (`{z}/{x}/{y}/{key}.svgz`); empty if the tile holds
+/// nothing. The pyramid is reconstructed deterministically from `bounds`, so
+/// these match what [`build_tileset`] would have produced eagerly.
+pub fn render_tile(
+    bounds: WorldBox,
+    index: &BspIndex,
+    z: u32,
+    x: u32,
+    y: u32,
+) -> Vec<(String, Vec<u8>)> {
+    let pyramid = Pyramid::new(bounds, RES_MIN_NM_PER_PX);
+    render_tile_inner(&pyramid, &bounds, index, z, x, y)
+}
+
+fn render_tile_inner(
+    pyramid: &Pyramid,
+    bounds: &WorldBox,
+    index: &BspIndex,
+    z: u32,
+    tx: u32,
+    ty: u32,
+) -> Vec<(String, Vec<u8>)> {
+    let tbox = pyramid.tile_world_box(z, tx, ty);
+    let mut out = Vec::new();
+    if !tbox.intersects(bounds) {
+        return out;
+    }
+    let hits = index.query_records(&tbox);
+    if hits.is_empty() {
+        return out;
+    }
+    let res_z = pyramid.res(z);
+    let mut by_layer: HashMap<(i16, i16), Vec<&PlacedRecord>> = HashMap::new();
+    for r in hits {
+        by_layer.entry((r.layer, r.datatype)).or_default().push(r);
+    }
+    let mut all_omitted: Vec<&PlacedRecord> = Vec::new();
+    for ((layer, datatype), recs) in &by_layer {
+        let (kept, omitted) = lod_partition(recs, res_z);
+        all_omitted.extend(omitted);
+        if kept.is_empty() {
+            continue;
+        }
+        let color = palette_color(*layer, *datatype);
+        let svg = render_layer_tile(&kept, &tbox, &color);
+        out.push((format!("{z}/{tx}/{ty}/{layer}_{datatype}.svgz"), svgz(&svg)));
+    }
+    if !all_omitted.is_empty() {
+        let svg = render_overlay(&all_omitted, &tbox);
+        out.push((format!("{z}/{tx}/{ty}/{LOD_KEY}.svgz"), svgz(&svg)));
+    }
+    out
 }
 
 #[cfg(test)]

--- a/crates/server/src/gdsii_tiles.rs
+++ b/crates/server/src/gdsii_tiles.rs
@@ -1,0 +1,261 @@
+//! GDSII tile viewer: ingest + serving routes.
+//!
+//! On upload of a `.gds`/`.gds2` file, [`ingest`] builds the tile set
+//! (manifest + serialized BSP index + eager tiles) and stores it under
+//! `gdsii/{id}/`. The routes serve the viewer shell, the manifest, and tiles
+//! (pull-through cache; deep-zoom tiles are rendered on demand from the cached
+//! index). Viewer assets are served from `GDS_VIEWER_DIR` at `/gview/`.
+
+use std::time::Duration;
+
+use axum::{
+    body::Body,
+    extract::{Path, State},
+    http::{header, StatusCode, Uri},
+    response::{Html, IntoResponse, Response},
+};
+use pcb_extract::parsers::gdsii::bsp::BspIndex;
+use pcb_extract::parsers::gdsii::tile::WorldBox;
+use pcb_extract::parsers::gdsii::tileset::{self, Manifest};
+use uuid::Uuid;
+
+use crate::AppState;
+
+/// Zoom levels pre-rendered at ingest; deeper levels render on demand.
+const EAGER_MAX_Z: u32 = 5;
+const INGEST_TIMEOUT: Duration = Duration::from_secs(120);
+const SEMAPHORE_TIMEOUT: Duration = Duration::from_secs(30);
+
+fn err(status: StatusCode, msg: &str) -> Response {
+    (status, msg.to_string()).into_response()
+}
+
+/// Reject ids that aren't UUIDs (storage-key path-traversal guard).
+fn valid_id(id: &str) -> bool {
+    Uuid::parse_str(id).is_ok()
+}
+
+/// Tile `key` must be `"{layer}_{datatype}"` or `"__lod"` — restrict to a safe
+/// charset so it can't escape the tile directory.
+fn valid_tile_key(key: &str) -> bool {
+    !key.is_empty()
+        && key.len() <= 32
+        && key
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b'-')
+}
+
+/// Build and store the tile set for an uploaded GDSII file. Returns on success
+/// with artifacts written under `gdsii/{id}/`.
+pub async fn ingest(state: &AppState, id: &str, data: Vec<u8>) -> Result<(), String> {
+    // Archive the original upload.
+    let _ = state
+        .s3
+        .put_object(
+            &format!("gdsii/{id}/raw.gds"),
+            data.clone(),
+            "application/octet-stream",
+        )
+        .await;
+
+    // Build the tile set off the async runtime, bounded by the parse semaphore
+    // and a wall-clock timeout (tiling is CPU-heavy).
+    let _permit = tokio::time::timeout(SEMAPHORE_TIMEOUT, state.parse_semaphore.acquire())
+        .await
+        .map_err(|_| "Server busy — try again later".to_string())?
+        .map_err(|_| "Server busy".to_string())?;
+
+    let id_owned = id.to_string();
+    let tileset = tokio::time::timeout(
+        INGEST_TIMEOUT,
+        tokio::task::spawn_blocking(move || tileset::build_tileset(&id_owned, &data, EAGER_MAX_Z)),
+    )
+    .await
+    .map_err(|_| "GDSII tiling timed out".to_string())?
+    .map_err(|_| "Tiling task failed".to_string())?
+    .map_err(|e| format!("Failed to tile GDSII: {e}"))?;
+
+    let manifest_json = serde_json::to_vec(&tileset.manifest)
+        .map_err(|_| "Manifest serialization failed".to_string())?;
+    state
+        .s3
+        .put_object(
+            &format!("gdsii/{id}/manifest.json"),
+            manifest_json,
+            "application/json",
+        )
+        .await
+        .map_err(|_| "Failed to store manifest".to_string())?;
+
+    let _ = state
+        .s3
+        .put_object(
+            &format!("gdsii/{id}/index.bin"),
+            tileset.index_bytes,
+            "application/octet-stream",
+        )
+        .await;
+
+    for (path, body) in tileset.tiles {
+        let _ = state
+            .s3
+            .put_object(&format!("gdsii/{id}/tiles/{path}"), body, "image/svg+xml")
+            .await;
+    }
+
+    Ok(())
+}
+
+/// Serve the GDSII viewer shell at `/g/{id}` (the WASM app reads the id from the
+/// path and fetches the manifest).
+pub async fn get_gds_viewer(State(state): State<AppState>, Path(id): Path<String>) -> Response {
+    if !valid_id(&id) {
+        return err(StatusCode::NOT_FOUND, "not found");
+    }
+    if state
+        .s3
+        .get_object(&format!("gdsii/{id}/manifest.json"))
+        .await
+        .is_err()
+    {
+        return err(StatusCode::NOT_FOUND, "GDSII view not found");
+    }
+    let index_path = state.gds_viewer_dir.join("index.html");
+    match tokio::fs::read_to_string(&index_path).await {
+        Ok(html) => Html(html).into_response(),
+        Err(_) => err(StatusCode::INTERNAL_SERVER_ERROR, "Viewer not available"),
+    }
+}
+
+/// Serve the tile-set manifest.
+pub async fn get_gds_manifest(State(state): State<AppState>, Path(id): Path<String>) -> Response {
+    if !valid_id(&id) {
+        return err(StatusCode::NOT_FOUND, "not found");
+    }
+    match state
+        .s3
+        .get_object(&format!("gdsii/{id}/manifest.json"))
+        .await
+    {
+        Ok(bytes) => (
+            StatusCode::OK,
+            [
+                (header::CONTENT_TYPE, "application/json"),
+                (header::CACHE_CONTROL, "public, max-age=300"),
+            ],
+            bytes,
+        )
+            .into_response(),
+        Err(_) => err(StatusCode::NOT_FOUND, "manifest not found"),
+    }
+}
+
+/// Serve one tile, `{key}` = `"{layer}_{datatype}"` or `"__lod"`. Pull-through
+/// cache: a miss for a deep-zoom tile is rendered on demand from the cached
+/// index and stored. Bodies are gzipped SVG (`Content-Encoding: gzip`).
+pub async fn get_gds_tile(
+    State(state): State<AppState>,
+    Path((id, z, x, y, key)): Path<(String, u32, u32, u32, String)>,
+) -> Response {
+    if !valid_id(&id) || !valid_tile_key(&key) {
+        return err(StatusCode::NOT_FOUND, "not found");
+    }
+    let tile_key = format!("gdsii/{id}/tiles/{z}/{x}/{y}/{key}.svgz");
+
+    if let Ok(cached) = state.s3.get_object(&tile_key).await {
+        return svgz_response(cached);
+    }
+
+    // Cache miss — render this tile on demand from the cached index + manifest.
+    let Ok(manifest_bytes) = state
+        .s3
+        .get_object(&format!("gdsii/{id}/manifest.json"))
+        .await
+    else {
+        return err(StatusCode::NOT_FOUND, "view not found");
+    };
+    let Ok(manifest) = serde_json::from_slice::<Manifest>(&manifest_bytes) else {
+        return err(StatusCode::INTERNAL_SERVER_ERROR, "bad manifest");
+    };
+    if z > manifest.zoom.max {
+        return err(StatusCode::NOT_FOUND, "zoom level out of range");
+    }
+    let Ok(index_bytes) = state.s3.get_object(&format!("gdsii/{id}/index.bin")).await else {
+        return err(StatusCode::NOT_FOUND, "index not found");
+    };
+
+    let bounds = WorldBox {
+        minx: manifest.extent_nm.minx,
+        miny: manifest.extent_nm.miny,
+        maxx: manifest.extent_nm.maxx,
+        maxy: manifest.extent_nm.maxy,
+    };
+    let blobs = match tokio::task::spawn_blocking(move || {
+        BspIndex::from_bytes(&index_bytes)
+            .map(|index| tileset::render_tile(bounds, &index, z, x, y))
+    })
+    .await
+    {
+        Ok(Ok(b)) => b,
+        _ => return err(StatusCode::INTERNAL_SERVER_ERROR, "tile render failed"),
+    };
+
+    // Store every layer blob for this tile; return the requested one.
+    let want = format!("{z}/{x}/{y}/{key}.svgz");
+    let mut found: Option<Vec<u8>> = None;
+    for (path, body) in blobs {
+        if path == want {
+            found = Some(body.clone());
+        }
+        let _ = state
+            .s3
+            .put_object(&format!("gdsii/{id}/tiles/{path}"), body, "image/svg+xml")
+            .await;
+    }
+    match found {
+        Some(body) => svgz_response(body),
+        // Empty tile for this layer — 204 so the viewer simply skips it.
+        None => StatusCode::NO_CONTENT.into_response(),
+    }
+}
+
+fn svgz_response(body: Vec<u8>) -> Response {
+    (
+        StatusCode::OK,
+        [
+            (header::CONTENT_TYPE, "image/svg+xml"),
+            (header::CONTENT_ENCODING, "gzip"),
+            (header::CACHE_CONTROL, "public, max-age=86400"),
+        ],
+        body,
+    )
+        .into_response()
+}
+
+/// Serve GDSII viewer static assets from `GDS_VIEWER_DIR` at `/gview/`, with an
+/// SPA fallback to `index.html`.
+pub async fn serve_gview(State(state): State<AppState>, uri: Uri) -> Response {
+    let rel = uri.path().trim_start_matches("/gview/");
+    let rel = if rel.is_empty() { "index.html" } else { rel };
+    // Reject traversal; only serve plain relative paths.
+    if rel.contains("..") {
+        return err(StatusCode::NOT_FOUND, "not found");
+    }
+    let path = state.gds_viewer_dir.join(rel);
+    let bytes = match tokio::fs::read(&path).await {
+        Ok(b) => b,
+        Err(_) => match tokio::fs::read(state.gds_viewer_dir.join("index.html")).await {
+            Ok(b) => b,
+            Err(_) => return err(StatusCode::NOT_FOUND, "asset not found"),
+        },
+    };
+    let mime = mime_guess::from_path(&path)
+        .first_or_octet_stream()
+        .to_string();
+    (
+        StatusCode::OK,
+        [(header::CONTENT_TYPE, mime)],
+        Body::from(bytes),
+    )
+        .into_response()
+}

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -1,4 +1,5 @@
 mod compressed_assets;
+mod gdsii_tiles;
 mod github;
 mod reparse;
 mod routes;
@@ -29,6 +30,14 @@ async fn main() {
         std::env::var("VIEWER_DIR").unwrap_or_else(|_| "crates/viewer/dist".to_string()),
     );
     tracing::info!("Serving viewer assets from {}", viewer_dir.display());
+
+    let gds_viewer_dir = PathBuf::from(
+        std::env::var("GDS_VIEWER_DIR").unwrap_or_else(|_| "crates/gds-viewer/dist".to_string()),
+    );
+    tracing::info!(
+        "Serving GDSII viewer assets from {}",
+        gds_viewer_dir.display()
+    );
 
     let recent = routes::load_recent(&s3_client).await;
     tracing::info!("Loaded {} recent public uploads", recent.len());
@@ -64,6 +73,7 @@ async fn main() {
     let state = AppState {
         s3: s3_client,
         viewer_dir: viewer_dir.clone(),
+        gds_viewer_dir,
         recent: Arc::new(RwLock::new(recent)),
         http_client,
         max_upload_bytes,
@@ -106,6 +116,7 @@ pub fn build_app(state: AppState) -> Router {
 pub struct AppState {
     pub s3: s3::S3Client,
     pub viewer_dir: PathBuf,
+    pub gds_viewer_dir: PathBuf,
     pub recent: Arc<RwLock<Vec<routes::RecentEntry>>>,
     pub http_client: reqwest::Client,
     pub max_upload_bytes: usize,
@@ -126,6 +137,7 @@ mod tests {
         AppState {
             s3,
             viewer_dir,
+            gds_viewer_dir: PathBuf::from("crates/gds-viewer/dist"),
             recent: Arc::new(RwLock::new(Vec::new())),
             http_client: reqwest::Client::new(),
             max_upload_bytes: 50 * 1024 * 1024,
@@ -176,6 +188,44 @@ mod tests {
         let resp = app
             .oneshot(
                 Request::get("/b/00000000-0000-0000-0000-000000000000/data")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 404);
+    }
+
+    #[tokio::test]
+    async fn test_gds_invalid_id_is_404() {
+        let app = build_app(test_state().await);
+        let resp = app
+            .oneshot(Request::get("/g/not-a-uuid").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 404);
+    }
+
+    #[tokio::test]
+    async fn test_gds_missing_manifest_is_404() {
+        let app = build_app(test_state().await);
+        let resp = app
+            .oneshot(
+                Request::get("/g/00000000-0000-0000-0000-000000000000/manifest.json")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 404);
+    }
+
+    #[tokio::test]
+    async fn test_gds_tile_bad_key_is_404() {
+        let app = build_app(test_state().await);
+        let resp = app
+            .oneshot(
+                Request::get("/g/00000000-0000-0000-0000-000000000000/tiles/0/0/0/bad..key")
                     .body(Body::empty())
                     .unwrap(),
             )

--- a/crates/server/src/routes.rs
+++ b/crates/server/src/routes.rs
@@ -178,6 +178,18 @@ pub fn router(max_upload_bytes: usize) -> Router<AppState> {
         .route("/b/{id}/meta", get(get_meta))
         .route("/b/{id}/thumb.svg", get(get_thumb_svg))
         .route("/gh-render", get(crate::github::gh_render))
+        // GDSII tile viewer
+        .route("/g/{id}", get(crate::gdsii_tiles::get_gds_viewer))
+        .route(
+            "/g/{id}/manifest.json",
+            get(crate::gdsii_tiles::get_gds_manifest),
+        )
+        .route(
+            "/g/{id}/tiles/{z}/{x}/{y}/{key}",
+            get(crate::gdsii_tiles::get_gds_tile),
+        )
+        .route("/gview/{*path}", get(crate::gdsii_tiles::serve_gview))
+        .route("/gview/", get(crate::gdsii_tiles::serve_gview))
         .route("/health", get(health))
         .layer(DefaultBodyLimit::max(max_upload_bytes))
 }
@@ -262,6 +274,26 @@ async fn upload(
 
     let (filename, data) =
         file_data.ok_or_else(|| error_response(StatusCode::BAD_REQUEST, "No file uploaded"))?;
+
+    // GDSII goes to the tile-viewer pipeline, not the PcbData/BOM path.
+    let lower = filename.to_lowercase();
+    if lower.ends_with(".gds") || lower.ends_with(".gds2") {
+        let id = Uuid::new_v4().to_string();
+        crate::gdsii_tiles::ingest(&state, &id, data)
+            .await
+            .map_err(|e| {
+                tracing::error!("GDSII ingest error for {filename}: {e}");
+                error_response(StatusCode::UNPROCESSABLE_ENTITY, &e)
+            })?;
+        let base_url =
+            std::env::var("BASE_URL").unwrap_or_else(|_| "http://localhost:8000".to_string());
+        return Ok(Json(UploadResponse {
+            url: format!("{base_url}/g/{id}"),
+            id,
+            filename,
+            components: 0,
+        }));
+    }
 
     let path = std::path::Path::new(&filename);
     let format = pcb_extract::detect_format_with_content(path, &data)


### PR DESCRIPTION
Milestones 6 (ingest) + 7 (routes) of the GDSII tile viewer — the server side that makes it work end to end.

- **Ingest**: `/upload` routes `.gds`/`.gds2` to the tile pipeline instead of the BOM path — `build_tileset` runs in `spawn_blocking` bounded by the parse semaphore + a timeout, and the artifacts are stored under `gdsii/{id}/` (`raw.gds`, `manifest.json`, `index.bin`, eager `tiles/...`). Returns `/g/{id}`.
- **Serving routes**:
  - `GET /g/{id}` → the gds-viewer shell (from `GDS_VIEWER_DIR`),
  - `GET /g/{id}/manifest.json` → the manifest,
  - `GET /g/{id}/tiles/{z}/{x}/{y}/{key}` → **pull-through cache**; a miss on a deep-zoom level renders the tile on demand from the cached `index.bin` (gzip, `Content-Encoding: gzip` so the viewer's `<img>` decompresses it),
  - `GET /gview/...` → gds-viewer static assets.
- Adds `tileset::render_tile` for single-tile on-demand generation (reused by `build_tileset`).
- **Security**: UUID id validation + tile-key charset validation guard storage-key traversal (mirrors the existing `validate_id`).

Pairs with the gds-viewer crate (#251). Server tests: invalid id, missing view, bad tile key → 404. Suite 255 (pcb-extract) + 21 (server) green; clippy `-D warnings` clean.