### PR TITLE
Point GDS_VIEWER_DIR at the image's gds-viewer dist

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,7 @@ COPY --from=builder /build/crates/gds-viewer/dist /app/gview
 
 ENV BIND_ADDR=0.0.0.0:8080
 ENV VIEWER_DIR=/app/viewer
+ENV GDS_VIEWER_DIR=/app/gview
 ENV STORAGE_PATH=/app/data
 ENV RUST_LOG=info
 ENV MAX_UPLOAD_SIZE=52428800


### PR DESCRIPTION
Integration fix for the GDSII tile viewer: the Dockerfile copies the gds-viewer dist to `/app/gview`, but the server's `GDS_VIEWER_DIR` defaulted to the source path (`crates/gds-viewer/dist`), so the container couldn't serve `/g/{id}` or `/gview/`. Sets `ENV GDS_VIEWER_DIR=/app/gview` to mirror `VIEWER_DIR=/app/viewer`.