### PR TITLE
Add All/None layer toggle to GDSII viewer

### DIFF
--- a/crates/gds-viewer/src/main.rs
+++ b/crates/gds-viewer/src/main.rs
@@ -561,9 +561,26 @@ fn render_panel(
         })
         .collect();
 
+    let show_all = {
+        let view = view.clone();
+        let redraw = redraw.clone();
+        Callback::from(move |_: MouseEvent| set_all_visible(&view, &redraw, true))
+    };
+    let hide_all = {
+        let view = view.clone();
+        let redraw = redraw.clone();
+        Callback::from(move |_: MouseEvent| set_all_visible(&view, &redraw, false))
+    };
+
     html! {
         <div class="gds-panel">
-            <h1>{ "Layers" }</h1>
+            <div class="gds-panel-head">
+                <h1>{ "Layers" }</h1>
+                <div class="gds-allnone">
+                    <button type="button" class="gds-btn" onclick={show_all}>{ "All" }</button>
+                    <button type="button" class="gds-btn" onclick={hide_all}>{ "None" }</button>
+                </div>
+            </div>
             { rows }
         </div>
     }
@@ -595,6 +612,21 @@ fn mutate_layer<F: Fn(&mut LayerState)>(
             view.set(Some(vs));
             redraw.set(**redraw + 1);
         }
+    }
+}
+
+/// Show or hide every layer at once (the panel's All / None control).
+fn set_all_visible(
+    view: &UseStateHandle<Option<ViewState>>,
+    redraw: &UseStateHandle<u64>,
+    visible: bool,
+) {
+    if let Some(mut vs) = (**view).clone() {
+        for ls in &mut vs.layers {
+            ls.visible = visible;
+        }
+        view.set(Some(vs));
+        redraw.set(**redraw + 1);
     }
 }
 

--- a/crates/gds-viewer/style.css
+++ b/crates/gds-viewer/style.css
@@ -72,10 +72,37 @@ body {
     gap: 2px;
 }
 
+.gds-panel-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin: 4px 6px 8px;
+}
+
 .gds-panel h1 {
     font-size: 14px;
-    margin: 4px 6px 8px;
+    margin: 0;
     font-weight: 600;
+}
+
+.gds-allnone {
+    display: flex;
+    gap: 4px;
+}
+
+.gds-btn {
+    background: var(--row-hover);
+    color: var(--text);
+    border: 1px solid var(--panel-border);
+    border-radius: 4px;
+    padding: 2px 10px;
+    font-size: 12px;
+    cursor: pointer;
+}
+
+.gds-btn:hover {
+    border-color: var(--accent);
+    color: var(--accent);
 }
 
 .gds-row {


### PR DESCRIPTION
Adds **All** / **None** buttons to the GDSII viewer's Layers panel header.

Dense layouts (the sky130 ibex demo has 41 layers) made it tedious to isolate a few layers — you had to uncheck them one by one. The two buttons set every layer's visibility at once and persist through the same path as individual toggles, so the choice survives a reload.

- `set_all_visible` bulk mutator in `main.rs`
- Header restyled into a flex row (`gds-panel-head`) with `gds-btn` buttons

Built clean with `trunk build --release`; verified live on the ibex layout.