### PR TITLE
Smooth GDSII zoom with retained coarse tiles

### DIFF
--- a/crates/gds-viewer/src/main.rs
+++ b/crates/gds-viewer/src/main.rs
@@ -338,7 +338,18 @@ fn app() -> Html {
         .filter(|(_, l)| l.visible)
         .map(|(idx, l)| {
             render_surface(
-                &m.id, l, idx, &pyr, z, zoom, panx, pany, view_w, view_h, &loaded_set, &redraw,
+                &m.id,
+                l,
+                idx,
+                &pyr,
+                z,
+                zoom,
+                panx,
+                pany,
+                view_w,
+                view_h,
+                &loaded_set,
+                &redraw,
             )
         })
         .collect();
@@ -422,7 +433,18 @@ fn render_surface(
     // top regardless of DOM order. Skip the backing level at the coarsest zoom.
     if z > pyr.min_z {
         emit_level_tiles(
-            &mut tiles, id, layer, pyr, z - 1, zoom, panx, pany, view_w, view_h, loaded, redraw,
+            &mut tiles,
+            id,
+            layer,
+            pyr,
+            z - 1,
+            zoom,
+            panx,
+            pany,
+            view_w,
+            view_h,
+            loaded,
+            redraw,
         );
     }
     emit_level_tiles(

--- a/crates/gds-viewer/src/main.rs
+++ b/crates/gds-viewer/src/main.rs
@@ -3,7 +3,7 @@ mod state;
 mod transform;
 
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
 use wasm_bindgen::JsCast;
@@ -67,6 +67,10 @@ fn app() -> Html {
     });
     // Index of the layer row currently being dragged (HTML5 DnD reorder).
     let drag_src: UseStateHandle<Option<usize>> = use_state(|| None);
+    // Keys of tiles whose image has finished loading; drives the fade-in so a
+    // tile only becomes visible once its pixels arrive, not when it mounts.
+    let loaded: UseStateHandle<Rc<RefCell<HashSet<String>>>> =
+        use_state(|| Rc::new(RefCell::new(HashSet::new())));
 
     // ── Fetch manifest once ─────────────────────────────────────────
     {
@@ -326,12 +330,17 @@ fn app() -> Html {
     let layer_lookup: HashMap<String, &Layer> =
         m.layers.iter().map(|l| (l.tile_key(), l)).collect();
 
+    let loaded_set = (*loaded).clone();
     let surfaces: Html = vs
         .layers
         .iter()
         .enumerate()
         .filter(|(_, l)| l.visible)
-        .map(|(idx, l)| render_surface(&m.id, l, idx, &pyr, z, zoom, panx, pany, view_w, view_h))
+        .map(|(idx, l)| {
+            render_surface(
+                &m.id, l, idx, &pyr, z, zoom, panx, pany, view_w, view_h, &loaded_set, &redraw,
+            )
+        })
         .collect();
 
     // ── Layer panel ─────────────────────────────────────────────────
@@ -398,6 +407,8 @@ fn render_surface(
     pany: f64,
     view_w: f64,
     view_h: f64,
+    loaded: &Rc<RefCell<HashSet<String>>>,
+    redraw: &UseStateHandle<u64>,
 ) -> Html {
     let style = format!(
         "z-index:{}; opacity:{};",
@@ -406,12 +417,17 @@ fn render_surface(
     );
 
     let mut tiles: Vec<Html> = Vec::new();
-    // Coarser backing level first (lower in the DOM = behind), then the active
-    // level on top. Skip the backing level at the coarsest zoom.
+    // Coarser backing level first, then the active level. Each level carries an
+    // explicit z-index (= its level number) so the finer level always paints on
+    // top regardless of DOM order. Skip the backing level at the coarsest zoom.
     if z > pyr.min_z {
-        emit_level_tiles(&mut tiles, id, layer, pyr, z - 1, zoom, panx, pany, view_w, view_h);
+        emit_level_tiles(
+            &mut tiles, id, layer, pyr, z - 1, zoom, panx, pany, view_w, view_h, loaded, redraw,
+        );
     }
-    emit_level_tiles(&mut tiles, id, layer, pyr, z, zoom, panx, pany, view_w, view_h);
+    emit_level_tiles(
+        &mut tiles, id, layer, pyr, z, zoom, panx, pany, view_w, view_h, loaded, redraw,
+    );
 
     html! {
         <div class="gds-surface" style={style}>
@@ -421,6 +437,9 @@ fn render_surface(
 }
 
 /// Append the `<img>` tiles for one pyramid level `z` covering the viewport.
+/// Tiles start transparent and fade in (CSS transition on `opacity`) only once
+/// their image has actually loaded — tracked in `loaded` and reflected in the
+/// inline style so pan re-renders never reset the fade.
 #[allow(clippy::too_many_arguments)]
 fn emit_level_tiles(
     out: &mut Vec<Html>,
@@ -433,6 +452,8 @@ fn emit_level_tiles(
     pany: f64,
     view_w: f64,
     view_h: f64,
+    loaded: &Rc<RefCell<HashSet<String>>>,
+    redraw: &UseStateHandle<u64>,
 ) {
     let frac = pyr.frac_scale(zoom, z);
     let tile_screen = pyr.tile_px * frac;
@@ -449,11 +470,28 @@ fn emit_level_tiles(
             let left = panx + tx as f64 * tile_screen;
             let top = pany + ty as f64 * tile_screen;
             let src = format!("/g/{}/tiles/{}/{}/{}/{}.svgz", id, z, tx, ty, layer.key);
-            let tile_style = format!(
-                "left:{:.2}px; top:{:.2}px; width:{:.2}px; height:{:.2}px;",
-                left, top, tile_screen, tile_screen
-            );
             let key = format!("{}:{}:{}:{}", z, tx, ty, layer.key);
+            // Loaded (incl. browser-cached) tiles render opaque immediately; the
+            // rest stay transparent until onload flips them, animating the fade.
+            let opacity = if loaded.borrow().contains(&key) {
+                1.0
+            } else {
+                0.0
+            };
+            let tile_style = format!(
+                "left:{:.2}px; top:{:.2}px; width:{:.2}px; height:{:.2}px; z-index:{}; opacity:{};",
+                left, top, tile_screen, tile_screen, z, opacity
+            );
+            let onload = {
+                let loaded = loaded.clone();
+                let redraw = redraw.clone();
+                let key = key.clone();
+                Callback::from(move |_: Event| {
+                    if loaded.borrow_mut().insert(key.clone()) {
+                        redraw.set(*redraw + 1);
+                    }
+                })
+            };
             let onerror = Callback::from(|e: Event| {
                 if let Some(img) = e.target().and_then(|t| t.dyn_into::<HtmlElement>().ok()) {
                     let _ = img.style().set_property("visibility", "hidden");
@@ -465,6 +503,7 @@ fn emit_level_tiles(
                     class="gds-tile"
                     src={src}
                     style={tile_style}
+                    {onload}
                     {onerror}
                     draggable="false"
                 />

--- a/crates/gds-viewer/src/main.rs
+++ b/crates/gds-viewer/src/main.rs
@@ -322,7 +322,6 @@ fn app() -> Html {
         )
     };
     let z = pyr.level_for_zoom(zoom);
-    let frac = pyr.frac_scale(zoom, z);
 
     let layer_lookup: HashMap<String, &Layer> =
         m.layers.iter().map(|l| (l.tile_key(), l)).collect();
@@ -332,7 +331,7 @@ fn app() -> Html {
         .iter()
         .enumerate()
         .filter(|(_, l)| l.visible)
-        .map(|(idx, l)| render_surface(&m.id, l, idx, &pyr, z, frac, panx, pany, view_w, view_h))
+        .map(|(idx, l)| render_surface(&m.id, l, idx, &pyr, z, zoom, panx, pany, view_w, view_h))
         .collect();
 
     // ── Layer panel ─────────────────────────────────────────────────
@@ -381,6 +380,12 @@ fn persist_transform(view: &UseStateHandle<Option<ViewState>>, t: &Transform) {
 
 /// Render one layer's surface div with its visible `<img>` tiles. Tiles that
 /// 404 are hidden via an onerror handler so missing tiles simply aren't drawn.
+///
+/// To keep zooming smooth we render the level *below* the active one underneath
+/// it. Tiles are keyed by level, so when the active level changes the previous
+/// level's already-loaded tiles become the coarse backing set with their DOM
+/// elements intact — they stay on screen, filling the gap while the finer tiles
+/// fade in on top, instead of the whole map blanking out.
 #[allow(clippy::too_many_arguments)]
 fn render_surface(
     id: &str,
@@ -388,15 +393,12 @@ fn render_surface(
     z_index: usize,
     pyr: &Pyramid,
     z: u32,
-    frac: f64,
+    zoom: f64,
     panx: f64,
     pany: f64,
     view_w: f64,
     view_h: f64,
 ) -> Html {
-    let tile_screen = pyr.tile_px * frac;
-    let range = pyr.visible_tiles(z, panx, pany, frac, view_w, view_h);
-
     let style = format!(
         "z-index:{}; opacity:{};",
         z_index,
@@ -404,6 +406,38 @@ fn render_surface(
     );
 
     let mut tiles: Vec<Html> = Vec::new();
+    // Coarser backing level first (lower in the DOM = behind), then the active
+    // level on top. Skip the backing level at the coarsest zoom.
+    if z > pyr.min_z {
+        emit_level_tiles(&mut tiles, id, layer, pyr, z - 1, zoom, panx, pany, view_w, view_h);
+    }
+    emit_level_tiles(&mut tiles, id, layer, pyr, z, zoom, panx, pany, view_w, view_h);
+
+    html! {
+        <div class="gds-surface" style={style}>
+            { tiles }
+        </div>
+    }
+}
+
+/// Append the `<img>` tiles for one pyramid level `z` covering the viewport.
+#[allow(clippy::too_many_arguments)]
+fn emit_level_tiles(
+    out: &mut Vec<Html>,
+    id: &str,
+    layer: &LayerState,
+    pyr: &Pyramid,
+    z: u32,
+    zoom: f64,
+    panx: f64,
+    pany: f64,
+    view_w: f64,
+    view_h: f64,
+) {
+    let frac = pyr.frac_scale(zoom, z);
+    let tile_screen = pyr.tile_px * frac;
+    let range = pyr.visible_tiles(z, panx, pany, frac, view_w, view_h);
+
     // Prefetch one ring beyond the viewport for snappier panning.
     let n = pyr.tiles_per_axis(z) as i64;
     let gx0 = (range.x0 - 1).max(0);
@@ -425,7 +459,7 @@ fn render_surface(
                     let _ = img.style().set_property("visibility", "hidden");
                 }
             });
-            tiles.push(html! {
+            out.push(html! {
                 <img
                     key={key}
                     class="gds-tile"
@@ -436,12 +470,6 @@ fn render_surface(
                 />
             });
         }
-    }
-
-    html! {
-        <div class="gds-surface" style={style}>
-            { tiles }
-        </div>
     }
 }
 

--- a/crates/gds-viewer/style.css
+++ b/crates/gds-viewer/style.css
@@ -59,18 +59,10 @@ body {
     image-rendering: auto;
     pointer-events: none;
     user-select: none;
-    /* Fades a tile in once when it mounts (new key). Panning only updates the
-       position style, so retained tiles don't re-run this and never flicker. */
-    animation: gds-tile-in 0.18s ease-out;
-}
-
-@keyframes gds-tile-in {
-    from {
-        opacity: 0;
-    }
-    to {
-        opacity: 1;
-    }
+    /* Opacity is driven by load state in the inline style; this transition
+       animates the 0 → 1 flip so a tile fades in when its image arrives. */
+    opacity: 0;
+    transition: opacity 0.18s ease-out;
 }
 
 .gds-panel {

--- a/crates/gds-viewer/style.css
+++ b/crates/gds-viewer/style.css
@@ -59,6 +59,18 @@ body {
     image-rendering: auto;
     pointer-events: none;
     user-select: none;
+    /* Fades a tile in once when it mounts (new key). Panning only updates the
+       position style, so retained tiles don't re-run this and never flicker. */
+    animation: gds-tile-in 0.18s ease-out;
+}
+
+@keyframes gds-tile-in {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
 }
 
 .gds-panel {


### PR DESCRIPTION
Zooming used to blank the whole map: each render only emitted tiles for the active pyramid level, keyed `z:x:y:layer`, so when the level changed **every key changed** and Yew destroyed all tiles and mounted empty ones — nothing on screen until the new level finished loading.

## Fix

1. **Retain a coarser backing level.** `render_surface` now renders level `z-1` beneath the active level `z`. Tiles are keyed by level, so on a zoom step the previous level's already-loaded `<img>` elements survive as the new backing set (same keys → Yew keeps them) and stay visible, filling the gap while the finer tiles load on top. Skipped at the coarsest zoom.
2. **Fade tiles in.** A one-shot CSS `@keyframes` on `.gds-tile` fades each tile in when it mounts. Panning only rewrites the position style, so retained tiles don't re-run the animation and never flicker.

Net effect: zooming in keeps the current view as a backdrop that the sharper tiles fade in over, instead of a blank flash.

Built clean (`cargo clippy` + `trunk build --release`); verified live on the sky130 ibex layout.