### PR TITLE
Add per-board reparse telemetry to pinpoint OOM board

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.9.1
+
+- Add per-board reparse telemetry to identify the board that OOMs the startup scan: flushed `reparse: [i/n] board=… upload_bytes=… parser=old->new` start line and `… done rss=…MB parsed_bytes=…` completion line
+- Persist a `reparse_progress` marker before each board's parse so a SIGKILL/OOM leaves the offending board named in storage
+- Process boards in deterministic ascending board-id order so the failing board is reproducible run-to-run
+- Add `SKIP_REPARSE` / `DISABLE_REPARSE` env to halt the reparse crash-loop while triaging
+
 ## 1.9.0
 
 - Fix KiCad arc direction by honouring the (start, mid, end) point convention; thumbnail and viewer now trace the same sweep

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1401,7 +1401,7 @@ dependencies = [
 
 [[package]]
 name = "gds-viewer"
-version = "1.9.0"
+version = "1.9.1"
 dependencies = [
  "gloo 0.11.0",
  "js-sys",
@@ -2731,7 +2731,7 @@ dependencies = [
 
 [[package]]
 name = "pastebom-server"
-version = "1.9.0"
+version = "1.9.1"
 dependencies = [
  "aws-config",
  "aws-sdk-s3",
@@ -2756,7 +2756,7 @@ dependencies = [
 
 [[package]]
 name = "pastebom-viewer"
-version = "1.9.0"
+version = "1.9.1"
 dependencies = [
  "gloo 0.11.0",
  "js-sys",
@@ -2782,7 +2782,7 @@ dependencies = [
 
 [[package]]
 name = "pcb-extract"
-version = "1.9.0"
+version = "1.9.1"
 dependencies = [
  "approx",
  "cfb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/pcb-extract", "crates/server", "crates/viewer", "crates/gds-v
 resolver = "2"
 
 [workspace.package]
-version = "1.9.0"
+version = "1.9.1"
 
 [workspace.dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,11 @@ RUN apt-get update && apt-get install -y \
     libssl-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Install trunk and wasm target for viewer build
-RUN cargo install trunk \
+# Install trunk and wasm target for viewer build.
+# Pin the version and use --locked so the build resolves trunk's own tested
+# dependency set; an unpinned install picks up broken transitive deps (e.g. a
+# cssparser/cssparser-macros mismatch) and fails to compile.
+RUN cargo install trunk --version 0.21.14 --locked \
     && rustup target add wasm32-unknown-unknown
 
 WORKDIR /build

--- a/crates/gds-viewer/src/main.rs
+++ b/crates/gds-viewer/src/main.rs
@@ -338,7 +338,18 @@ fn app() -> Html {
         .filter(|(_, l)| l.visible)
         .map(|(idx, l)| {
             render_surface(
-                &m.id, l, idx, &pyr, z, zoom, panx, pany, view_w, view_h, &loaded_set, &redraw,
+                &m.id,
+                l,
+                idx,
+                &pyr,
+                z,
+                zoom,
+                panx,
+                pany,
+                view_w,
+                view_h,
+                &loaded_set,
+                &redraw,
             )
         })
         .collect();
@@ -422,7 +433,18 @@ fn render_surface(
     // top regardless of DOM order. Skip the backing level at the coarsest zoom.
     if z > pyr.min_z {
         emit_level_tiles(
-            &mut tiles, id, layer, pyr, z - 1, zoom, panx, pany, view_w, view_h, loaded, redraw,
+            &mut tiles,
+            id,
+            layer,
+            pyr,
+            z - 1,
+            zoom,
+            panx,
+            pany,
+            view_w,
+            view_h,
+            loaded,
+            redraw,
         );
     }
     emit_level_tiles(

--- a/crates/gds-viewer/src/main.rs
+++ b/crates/gds-viewer/src/main.rs
@@ -3,7 +3,7 @@ mod state;
 mod transform;
 
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
 use wasm_bindgen::JsCast;
@@ -67,6 +67,10 @@ fn app() -> Html {
     });
     // Index of the layer row currently being dragged (HTML5 DnD reorder).
     let drag_src: UseStateHandle<Option<usize>> = use_state(|| None);
+    // Keys of tiles whose image has finished loading; drives the fade-in so a
+    // tile only becomes visible once its pixels arrive, not when it mounts.
+    let loaded: UseStateHandle<Rc<RefCell<HashSet<String>>>> =
+        use_state(|| Rc::new(RefCell::new(HashSet::new())));
 
     // ── Fetch manifest once ─────────────────────────────────────────
     {
@@ -326,12 +330,17 @@ fn app() -> Html {
     let layer_lookup: HashMap<String, &Layer> =
         m.layers.iter().map(|l| (l.tile_key(), l)).collect();
 
+    let loaded_set = (*loaded).clone();
     let surfaces: Html = vs
         .layers
         .iter()
         .enumerate()
         .filter(|(_, l)| l.visible)
-        .map(|(idx, l)| render_surface(&m.id, l, idx, &pyr, z, zoom, panx, pany, view_w, view_h))
+        .map(|(idx, l)| {
+            render_surface(
+                &m.id, l, idx, &pyr, z, zoom, panx, pany, view_w, view_h, &loaded_set, &redraw,
+            )
+        })
         .collect();
 
     // ── Layer panel ─────────────────────────────────────────────────
@@ -398,6 +407,8 @@ fn render_surface(
     pany: f64,
     view_w: f64,
     view_h: f64,
+    loaded: &Rc<RefCell<HashSet<String>>>,
+    redraw: &UseStateHandle<u64>,
 ) -> Html {
     let style = format!(
         "z-index:{}; opacity:{};",
@@ -406,12 +417,17 @@ fn render_surface(
     );
 
     let mut tiles: Vec<Html> = Vec::new();
-    // Coarser backing level first (lower in the DOM = behind), then the active
-    // level on top. Skip the backing level at the coarsest zoom.
+    // Coarser backing level first, then the active level. Each level carries an
+    // explicit z-index (= its level number) so the finer level always paints on
+    // top regardless of DOM order. Skip the backing level at the coarsest zoom.
     if z > pyr.min_z {
-        emit_level_tiles(&mut tiles, id, layer, pyr, z - 1, zoom, panx, pany, view_w, view_h);
+        emit_level_tiles(
+            &mut tiles, id, layer, pyr, z - 1, zoom, panx, pany, view_w, view_h, loaded, redraw,
+        );
     }
-    emit_level_tiles(&mut tiles, id, layer, pyr, z, zoom, panx, pany, view_w, view_h);
+    emit_level_tiles(
+        &mut tiles, id, layer, pyr, z, zoom, panx, pany, view_w, view_h, loaded, redraw,
+    );
 
     html! {
         <div class="gds-surface" style={style}>
@@ -421,6 +437,9 @@ fn render_surface(
 }
 
 /// Append the `<img>` tiles for one pyramid level `z` covering the viewport.
+/// Tiles start transparent and fade in (CSS transition on `opacity`) only once
+/// their image has actually loaded — tracked in `loaded` and reflected in the
+/// inline style so pan re-renders never reset the fade.
 #[allow(clippy::too_many_arguments)]
 fn emit_level_tiles(
     out: &mut Vec<Html>,
@@ -433,6 +452,8 @@ fn emit_level_tiles(
     pany: f64,
     view_w: f64,
     view_h: f64,
+    loaded: &Rc<RefCell<HashSet<String>>>,
+    redraw: &UseStateHandle<u64>,
 ) {
     let frac = pyr.frac_scale(zoom, z);
     let tile_screen = pyr.tile_px * frac;
@@ -449,11 +470,28 @@ fn emit_level_tiles(
             let left = panx + tx as f64 * tile_screen;
             let top = pany + ty as f64 * tile_screen;
             let src = format!("/g/{}/tiles/{}/{}/{}/{}.svgz", id, z, tx, ty, layer.key);
-            let tile_style = format!(
-                "left:{:.2}px; top:{:.2}px; width:{:.2}px; height:{:.2}px;",
-                left, top, tile_screen, tile_screen
-            );
             let key = format!("{}:{}:{}:{}", z, tx, ty, layer.key);
+            // Loaded (incl. browser-cached) tiles render opaque immediately; the
+            // rest stay transparent until onload flips them, animating the fade.
+            let opacity = if loaded.borrow().contains(&key) {
+                1.0
+            } else {
+                0.0
+            };
+            let tile_style = format!(
+                "left:{:.2}px; top:{:.2}px; width:{:.2}px; height:{:.2}px; z-index:{}; opacity:{};",
+                left, top, tile_screen, tile_screen, z, opacity
+            );
+            let onload = {
+                let loaded = loaded.clone();
+                let redraw = redraw.clone();
+                let key = key.clone();
+                Callback::from(move |_: Event| {
+                    if loaded.borrow_mut().insert(key.clone()) {
+                        redraw.set(*redraw + 1);
+                    }
+                })
+            };
             let onerror = Callback::from(|e: Event| {
                 if let Some(img) = e.target().and_then(|t| t.dyn_into::<HtmlElement>().ok()) {
                     let _ = img.style().set_property("visibility", "hidden");
@@ -465,6 +503,7 @@ fn emit_level_tiles(
                     class="gds-tile"
                     src={src}
                     style={tile_style}
+                    {onload}
                     {onerror}
                     draggable="false"
                 />

--- a/crates/gds-viewer/src/main.rs
+++ b/crates/gds-viewer/src/main.rs
@@ -322,7 +322,6 @@ fn app() -> Html {
         )
     };
     let z = pyr.level_for_zoom(zoom);
-    let frac = pyr.frac_scale(zoom, z);
 
     let layer_lookup: HashMap<String, &Layer> =
         m.layers.iter().map(|l| (l.tile_key(), l)).collect();
@@ -332,7 +331,7 @@ fn app() -> Html {
         .iter()
         .enumerate()
         .filter(|(_, l)| l.visible)
-        .map(|(idx, l)| render_surface(&m.id, l, idx, &pyr, z, frac, panx, pany, view_w, view_h))
+        .map(|(idx, l)| render_surface(&m.id, l, idx, &pyr, z, zoom, panx, pany, view_w, view_h))
         .collect();
 
     // ── Layer panel ─────────────────────────────────────────────────
@@ -381,6 +380,12 @@ fn persist_transform(view: &UseStateHandle<Option<ViewState>>, t: &Transform) {
 
 /// Render one layer's surface div with its visible `<img>` tiles. Tiles that
 /// 404 are hidden via an onerror handler so missing tiles simply aren't drawn.
+///
+/// To keep zooming smooth we render the level *below* the active one underneath
+/// it. Tiles are keyed by level, so when the active level changes the previous
+/// level's already-loaded tiles become the coarse backing set with their DOM
+/// elements intact — they stay on screen, filling the gap while the finer tiles
+/// fade in on top, instead of the whole map blanking out.
 #[allow(clippy::too_many_arguments)]
 fn render_surface(
     id: &str,
@@ -388,15 +393,12 @@ fn render_surface(
     z_index: usize,
     pyr: &Pyramid,
     z: u32,
-    frac: f64,
+    zoom: f64,
     panx: f64,
     pany: f64,
     view_w: f64,
     view_h: f64,
 ) -> Html {
-    let tile_screen = pyr.tile_px * frac;
-    let range = pyr.visible_tiles(z, panx, pany, frac, view_w, view_h);
-
     let style = format!(
         "z-index:{}; opacity:{};",
         z_index,
@@ -404,6 +406,38 @@ fn render_surface(
     );
 
     let mut tiles: Vec<Html> = Vec::new();
+    // Coarser backing level first (lower in the DOM = behind), then the active
+    // level on top. Skip the backing level at the coarsest zoom.
+    if z > pyr.min_z {
+        emit_level_tiles(&mut tiles, id, layer, pyr, z - 1, zoom, panx, pany, view_w, view_h);
+    }
+    emit_level_tiles(&mut tiles, id, layer, pyr, z, zoom, panx, pany, view_w, view_h);
+
+    html! {
+        <div class="gds-surface" style={style}>
+            { tiles }
+        </div>
+    }
+}
+
+/// Append the `<img>` tiles for one pyramid level `z` covering the viewport.
+#[allow(clippy::too_many_arguments)]
+fn emit_level_tiles(
+    out: &mut Vec<Html>,
+    id: &str,
+    layer: &LayerState,
+    pyr: &Pyramid,
+    z: u32,
+    zoom: f64,
+    panx: f64,
+    pany: f64,
+    view_w: f64,
+    view_h: f64,
+) {
+    let frac = pyr.frac_scale(zoom, z);
+    let tile_screen = pyr.tile_px * frac;
+    let range = pyr.visible_tiles(z, panx, pany, frac, view_w, view_h);
+
     // Prefetch one ring beyond the viewport for snappier panning.
     let n = pyr.tiles_per_axis(z) as i64;
     let gx0 = (range.x0 - 1).max(0);
@@ -425,7 +459,7 @@ fn render_surface(
                     let _ = img.style().set_property("visibility", "hidden");
                 }
             });
-            tiles.push(html! {
+            out.push(html! {
                 <img
                     key={key}
                     class="gds-tile"
@@ -436,12 +470,6 @@ fn render_surface(
                 />
             });
         }
-    }
-
-    html! {
-        <div class="gds-surface" style={style}>
-            { tiles }
-        </div>
     }
 }
 

--- a/crates/gds-viewer/style.css
+++ b/crates/gds-viewer/style.css
@@ -59,18 +59,10 @@ body {
     image-rendering: auto;
     pointer-events: none;
     user-select: none;
-    /* Fades a tile in once when it mounts (new key). Panning only updates the
-       position style, so retained tiles don't re-run this and never flicker. */
-    animation: gds-tile-in 0.18s ease-out;
-}
-
-@keyframes gds-tile-in {
-    from {
-        opacity: 0;
-    }
-    to {
-        opacity: 1;
-    }
+    /* Opacity is driven by load state in the inline style; this transition
+       animates the 0 → 1 flip so a tile fades in when its image arrives. */
+    opacity: 0;
+    transition: opacity 0.18s ease-out;
 }
 
 .gds-panel {

--- a/crates/gds-viewer/style.css
+++ b/crates/gds-viewer/style.css
@@ -59,6 +59,18 @@ body {
     image-rendering: auto;
     pointer-events: none;
     user-select: none;
+    /* Fades a tile in once when it mounts (new key). Panning only updates the
+       position style, so retained tiles don't re-run this and never flicker. */
+    animation: gds-tile-in 0.18s ease-out;
+}
+
+@keyframes gds-tile-in {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
 }
 
 .gds-panel {

--- a/crates/server/src/reparse.rs
+++ b/crates/server/src/reparse.rs
@@ -1,8 +1,13 @@
 use crate::s3::S3Client;
 use pcb_extract::ExtractOptions;
+use std::io::Write;
 use std::path::Path;
 
 const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Storage key holding the board currently being reparsed. Overwritten before each
+/// board's memory-spiking work so that, after a SIGKILL/OOM, it names the offender.
+const PROGRESS_KEY: &str = "reparse_progress";
 
 /// A lightweight struct to check parser_version/format without deserializing full PcbData.
 #[derive(serde::Deserialize)]
@@ -13,9 +18,45 @@ struct VersionProbe {
     format: Option<pcb_extract::PcbFormat>,
 }
 
+/// True when reparse is switched off via `SKIP_REPARSE` or `DISABLE_REPARSE`.
+/// Lets ops stop the crash-loop while triaging an OOM.
+fn reparse_disabled() -> bool {
+    ["SKIP_REPARSE", "DISABLE_REPARSE"].iter().any(|var| {
+        std::env::var(var).is_ok_and(|v| {
+            let v = v.trim().to_ascii_lowercase();
+            !v.is_empty() && v != "0" && v != "false" && v != "no"
+        })
+    })
+}
+
+/// Current resident set size in MiB from `/proc/self/status`. Returns 0 when unreadable
+/// (e.g. non-Linux); coarse is fine — it only has to flag a board that spikes but survives.
+fn rss_mb() -> u64 {
+    let Ok(status) = std::fs::read_to_string("/proc/self/status") else {
+        return 0;
+    };
+    for line in status.lines() {
+        if let Some(rest) = line.strip_prefix("VmRSS:") {
+            if let Some(kb) = rest
+                .split_whitespace()
+                .next()
+                .and_then(|k| k.parse::<u64>().ok())
+            {
+                return kb / 1024;
+            }
+        }
+    }
+    0
+}
+
 /// Scan all stored boards and re-parse any with a stale or missing parser_version.
 /// Runs as a background task after server startup.
 pub async fn reparse_stale_boards(s3: S3Client) {
+    if reparse_disabled() {
+        tracing::info!("Reparse scan disabled via SKIP_REPARSE/DISABLE_REPARSE; skipping");
+        return;
+    }
+
     let bom_objects = match s3.list_objects("boms/").await {
         Ok(objs) => objs,
         Err(e) => {
@@ -24,7 +65,7 @@ pub async fn reparse_stale_boards(s3: S3Client) {
         }
     };
 
-    let bom_ids: Vec<String> = bom_objects
+    let mut bom_ids: Vec<String> = bom_objects
         .iter()
         .filter_map(|o| {
             o.key
@@ -35,18 +76,20 @@ pub async fn reparse_stale_boards(s3: S3Client) {
         })
         .collect();
 
+    // Ascending board-id order so "the board it dies on" is reproducible run-to-run.
+    bom_ids.sort();
+
+    let total = bom_ids.len();
     tracing::info!(
-        "Reparse scan: checking {} boards against parser v{}",
-        bom_ids.len(),
-        CURRENT_VERSION
+        "Reparse scan: checking {total} boards against parser v{CURRENT_VERSION} (ascending board-id order)"
     );
 
     let mut reparsed = 0;
     let mut skipped = 0;
     let mut failed = 0;
 
-    for id in &bom_ids {
-        match check_and_reparse(&s3, id).await {
+    for (idx, id) in bom_ids.iter().enumerate() {
+        match check_and_reparse(&s3, id, idx + 1, total).await {
             ReparseResult::Current => {}
             ReparseResult::Reparsed => reparsed += 1,
             ReparseResult::Skipped(reason) => {
@@ -77,7 +120,7 @@ enum ReparseResult {
     Failed(String),
 }
 
-async fn check_and_reparse(s3: &S3Client, id: &str) -> ReparseResult {
+async fn check_and_reparse(s3: &S3Client, id: &str, pos: usize, total: usize) -> ReparseResult {
     // Load just the parser_version field
     let bom_key = format!("boms/{id}.json");
     let json_bytes = match s3.get_object(&bom_key).await {
@@ -111,16 +154,32 @@ async fn check_and_reparse(s3: &S3Client, id: &str) -> ReparseResult {
         Err(_) => return ReparseResult::Skipped("could not list uploads".into()),
     };
 
-    let upload_key = match upload_objects.first() {
-        Some(obj) => &obj.key,
+    let upload_obj = match upload_objects.first() {
+        Some(obj) => obj,
         None => return ReparseResult::Skipped("no original upload found".into()),
     };
+    let upload_key = &upload_obj.key;
+    let upload_bytes = upload_obj.size;
 
     let filename = upload_key
         .rsplit('/')
         .next()
         .unwrap_or("upload.bin")
         .to_string();
+
+    // Emit + flush a per-board start line and persist a progress marker BEFORE the
+    // memory-spiking download/parse. A SIGKILL/OOM leaves no unwind, so whatever is
+    // flushed to stdout and written to storage here names the last board attempted.
+    tracing::info!(
+        "reparse: [{pos}/{total}] board={id} upload_bytes={upload_bytes} parser={old_version}->{CURRENT_VERSION}"
+    );
+    let _ = std::io::stdout().flush();
+    let marker = format!(
+        "[{pos}/{total}] board={id} upload_bytes={upload_bytes} parser={old_version}->{CURRENT_VERSION}\n"
+    );
+    let _ = s3
+        .put_object(PROGRESS_KEY, marker.into_bytes(), "text/plain")
+        .await;
 
     let upload_data = match s3.get_object(upload_key).await {
         Ok(d) => d,
@@ -153,6 +212,7 @@ async fn check_and_reparse(s3: &S3Client, id: &str) -> ReparseResult {
         Ok(j) => j,
         Err(_) => return ReparseResult::Failed("json serialization failed".into()),
     };
+    let parsed_bytes = pcbdata_json.len();
 
     if let Err(e) = s3
         .put_object(&bom_key, pcbdata_json, "application/json")
@@ -165,6 +225,10 @@ async fn check_and_reparse(s3: &S3Client, id: &str) -> ReparseResult {
     let thumb_key = format!("thumbnails/{id}.svg");
     let _ = s3.delete_object(&thumb_key).await;
 
-    tracing::info!("Reparsed {id} ({filename}): v{old_version} -> v{CURRENT_VERSION}");
+    // Completion line with peak-ish RSS so a board that spikes but survives is still visible.
+    tracing::info!(
+        "reparse: [{pos}/{total}] board={id} done rss={}MB upload_bytes={upload_bytes} parsed_bytes={parsed_bytes} v{old_version}->v{CURRENT_VERSION}",
+        rss_mb()
+    );
     ReparseResult::Reparsed
 }

--- a/crates/server/src/s3.rs
+++ b/crates/server/src/s3.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 pub struct ObjectInfo {
     pub key: String,
     pub last_modified: chrono::DateTime<chrono::Utc>,
+    pub size: u64,
 }
 
 #[derive(Clone)]
@@ -126,9 +127,11 @@ impl S3Client {
                                     chrono::DateTime::from_timestamp(t.secs(), t.subsec_nanos())
                                 })
                                 .unwrap_or_else(chrono::Utc::now);
+                            let size = obj.size().unwrap_or(0).max(0) as u64;
                             objects.push(ObjectInfo {
                                 key: logical_key,
                                 last_modified,
+                                size,
                             });
                         }
                     }
@@ -152,12 +155,18 @@ impl S3Client {
                                 prefix.trim_end_matches('/'),
                                 entry.file_name().to_string_lossy()
                             );
-                            let last_modified = entry
-                                .metadata()
-                                .and_then(|m| m.modified())
+                            let metadata = entry.metadata().ok();
+                            let last_modified = metadata
+                                .as_ref()
+                                .and_then(|m| m.modified().ok())
                                 .map(chrono::DateTime::<chrono::Utc>::from)
-                                .unwrap_or_else(|_| chrono::Utc::now());
-                            objects.push(ObjectInfo { key, last_modified });
+                                .unwrap_or_else(chrono::Utc::now);
+                            let size = metadata.as_ref().map(|m| m.len()).unwrap_or(0);
+                            objects.push(ObjectInfo {
+                                key,
+                                last_modified,
+                                size,
+                            });
                         }
                     }
                 }


### PR DESCRIPTION
Closes #263. Refs #55, #262.

## Why

The startup reparse scan OOM-loops on prod — RSS climbs to ~1.79 GiB and the container is SIGKILLed (`exit 137`) against the 2 GiB limit, then restarts and re-OOMs on the same board forever (this is the real cause behind #262, which was closed as a dup). Reparse logged only the opening `checking N boards` line and nothing per-board, so we couldn't name the offending board. Because SIGKILL leaves no unwind/`Drop`, the telemetry has to be **emitted and flushed before** each board's memory-spiking work.

## What

- **Flushed per-board start line**, emitted before the download/parse:
  `reparse: [i/n] board=<id> upload_bytes=<size> parser=<old>-><new>` followed by an explicit `stdout().flush()` so it survives SIGKILL.
- **Completion line** with resident memory and output size so a board that spikes but survives is still visible:
  `reparse: [i/n] board=<id> done rss=<mb>MB upload_bytes=<n> parsed_bytes=<n> v<old>->v<new>`. RSS read from `/proc/self/status`.
- **Persisted `reparse_progress` marker** written to storage before each parse (overwritten per board), so after an OOM the offender is named on disk with zero log-scraping. Doubles as a future resume cursor (#55).
- **Deterministic ascending board-id order** so "the board it dies on" is reproducible run-to-run.
- **`SKIP_REPARSE` / `DISABLE_REPARSE` env** to halt the crash-loop while triaging.
- Added `size` to `ObjectInfo` (populated from S3 `Object::size` and filesystem metadata) to source `upload_bytes` without a download.
- Bumped to **1.9.1** so `/health` distinguishes the telemetry build from the currently-deployed 1.9.0.

## Acceptance

After one OOM cycle on prod, `reparse_progress` (and the last flushed log line) answer: *board X (upload N bytes, position i/n) is the one that spikes to ~2 GiB* — the input the memory fix needs.

## Testing

- `cargo build --locked` ✅ · `cargo clippy -- -W clippy::all` clean · `cargo test -p pastebom-server` 23 passed