### PR TITLE
Fix KiCad pad angle double-counting footprint rotation

### DIFF
--- a/crates/pcb-extract/src/parsers/kicad.rs
+++ b/crates/pcb-extract/src/parsers/kicad.rs
@@ -691,10 +691,12 @@ fn parse_pad(node: &SExpr, fp_x: f64, fp_y: f64, fp_angle: f64, nets: &[String])
         size: [size_w, size_h],
         shape: shape.to_string(),
         pad_type: pad_type.to_string(),
+        // KiCad stores the pad `at` angle as an absolute board orientation that already
+        // includes the footprint's rotation (unlike the pad position, which is local and
+        // rotated above). Adding fp_angle here would double-count it — visibly wrong at
+        // non-orthogonal footprint rotations (e.g. a 45° chip's leads).
         angle: if pad_angle != 0.0 {
-            Some(pad_angle + fp_angle)
-        } else if fp_angle != 0.0 {
-            Some(fp_angle)
+            Some(pad_angle)
         } else {
             None
         },
@@ -1290,5 +1292,39 @@ mod arc_tests {
             "sweep was {}°, expected 20°",
             forward_sweep(sa, ea)
         );
+    }
+}
+
+#[cfg(test)]
+mod pad_angle_tests {
+    use super::*;
+
+    fn pad_angle(fp_at: &str, pad_at: &str) -> Option<f64> {
+        let doc = format!(
+            "(kicad_pcb (footprint \"T\" (layer \"F.Cu\") (at {fp_at}) \
+             (pad \"1\" smd roundrect (at {pad_at}) (size 0.8 0.2) (layers \"F.Cu\"))))"
+        );
+        let opts = ExtractOptions {
+            include_tracks: false,
+            include_nets: false,
+        };
+        let data = parse(doc.as_bytes(), &opts).expect("parse");
+        data.footprints[0].pads[0].angle
+    }
+
+    #[test]
+    fn pad_angle_is_absolute_not_double_counted() {
+        // KiCad bakes the footprint rotation into the stored pad angle. A footprint at
+        // -45° with a pad the file records at 315° must stay 315° — not 270° (double-count).
+        assert_eq!(pad_angle("100 100 -45", "1 0 315"), Some(315.0));
+        // Orthogonal footprint: a pad recorded at 90° stays 90°, not 180°.
+        assert_eq!(pad_angle("100 100 90", "1 0 90"), Some(90.0));
+    }
+
+    #[test]
+    fn pad_with_zero_file_angle_stays_unrotated() {
+        // A pad the file records at 0° is absolutely axis-aligned even inside a rotated
+        // footprint; it must not inherit the footprint's rotation.
+        assert_eq!(pad_angle("100 100 -45", "1 0"), None);
     }
 }


### PR DESCRIPTION
## Symptom

On [this board](https://pastebom.com/b/b66af03f-e698-4a7f-acaf-b259479c3a6d), the central chip **U3** is rotated 45° and its pins render "doofed" — the elongated leads point ~45° off from where they should.

## Root cause

KiCad's `.kicad_pcb` stores a pad's `at` angle as an **absolute** board orientation that already includes the parent footprint's rotation. (Pad *position*, by contrast, is stored local and must be rotated by the footprint angle — which the parser does correctly.) The parser then added `fp_angle` on top of the already-absolute pad angle at `kicad.rs:695`, **double-counting** the rotation.

Confirmed against the real board data — every pad angle came out as exactly **2× the footprint rotation**:

| footprint angle | buggy pad angle | 2×fp |
|---|---|---|
| 90° | 180° | ✓ |
| −90° | 180° | ✓ |
| 180° | 360° | ✓ |
| **−45°** | **270°** | ✓ |

U3 is a 4-sided QFP whose leads encode side orientation via width/height swap (`0.8×0.2` vs `0.2×0.8`, all at local angle 0), so the correct absolute angle for every lead is just the footprint's −45°. The parser produced −90° (270°) instead.

At orthogonal footprint rotations the surplus angle is a 90°/180° multiple that rectangular-pad symmetry hides, which is why this went unnoticed until a 45°-rotated part exposed it.

## Fix

Use the file's pad angle as-is; don't add `fp_angle`. Because both the interactive viewer (`render.rs`) and the SVG thumbnail (`thumbnail.rs`) consume the same `PcbData.pad.angle`, this one parser fix corrects both render paths.

## Tests

Added `pad_angle_tests` covering a −45° footprint (must stay absolute, not double-count), an orthogonal case, and a zero-angle pad in a rotated footprint (must not inherit rotation). `cargo test -p pcb-extract` — 258 passed; clippy clean.

## Note

Version-neutral by repo convention (version bumps are separate dedicated PRs).