### PR TITLE
Stop reparse OOM on oversized and legacy GDSII boms

### DIFF
--- a/crates/server/src/reparse.rs
+++ b/crates/server/src/reparse.rs
@@ -9,6 +9,12 @@ const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
 /// board's memory-spiking work so that, after a SIGKILL/OOM, it names the offender.
 const PROGRESS_KEY: &str = "reparse_progress";
 
+/// Skip probing any bom JSON larger than this. The probe reads the whole object into
+/// memory to extract two fields, so a pathological legacy artifact (e.g. a 4.3 MB GDS
+/// that expanded to 1.2 GB of JSON) would OOM-kill the container. A real PCB bom is at
+/// most a few MB, so this only ever rejects degenerate records.
+const MAX_REPARSE_BOM_BYTES: u64 = 256 * 1024 * 1024;
+
 /// A lightweight struct to check parser_version/format without deserializing full PcbData.
 #[derive(serde::Deserialize)]
 struct VersionProbe {
@@ -27,6 +33,13 @@ fn reparse_disabled() -> bool {
             !v.is_empty() && v != "0" && v != "false" && v != "no"
         })
     })
+}
+
+/// True when an upload is a format no longer served (GDSII), detected by extension.
+fn is_unsupported_upload(filename: &str) -> bool {
+    Path::new(filename)
+        .extension()
+        .is_some_and(|e| e.eq_ignore_ascii_case("gds") || e.eq_ignore_ascii_case("gdsii"))
 }
 
 /// Current resident set size in MiB from `/proc/self/status`. Returns 0 when unreadable
@@ -65,21 +78,21 @@ pub async fn reparse_stale_boards(s3: S3Client) {
         }
     };
 
-    let mut bom_ids: Vec<String> = bom_objects
+    let mut boms: Vec<(String, u64)> = bom_objects
         .iter()
         .filter_map(|o| {
             o.key
                 .strip_prefix("boms/")
                 .and_then(|k| k.strip_suffix(".json"))
                 .filter(|k| !k.ends_with(".meta"))
-                .map(|k| k.to_string())
+                .map(|k| (k.to_string(), o.size))
         })
         .collect();
 
     // Ascending board-id order so "the board it dies on" is reproducible run-to-run.
-    bom_ids.sort();
+    boms.sort_by(|a, b| a.0.cmp(&b.0));
 
-    let total = bom_ids.len();
+    let total = boms.len();
     tracing::info!(
         "Reparse scan: checking {total} boards against parser v{CURRENT_VERSION} (ascending board-id order)"
     );
@@ -88,8 +101,8 @@ pub async fn reparse_stale_boards(s3: S3Client) {
     let mut skipped = 0;
     let mut failed = 0;
 
-    for (idx, id) in bom_ids.iter().enumerate() {
-        match check_and_reparse(&s3, id, idx + 1, total).await {
+    for (idx, (id, bom_size)) in boms.iter().enumerate() {
+        match check_and_reparse(&s3, id, *bom_size, idx + 1, total).await {
             ReparseResult::Current => {}
             ReparseResult::Reparsed => reparsed += 1,
             ReparseResult::Skipped(reason) => {
@@ -120,9 +133,27 @@ enum ReparseResult {
     Failed(String),
 }
 
-async fn check_and_reparse(s3: &S3Client, id: &str, pos: usize, total: usize) -> ReparseResult {
-    // Load just the parser_version field
+async fn check_and_reparse(
+    s3: &S3Client,
+    id: &str,
+    bom_size: u64,
+    pos: usize,
+    total: usize,
+) -> ReparseResult {
     let bom_key = format!("boms/{id}.json");
+
+    // Guard the probe download: reading a multi-gigabyte bom into memory to check two
+    // fields OOM-kills the container. Skip (and name it in the log, flushed) before any
+    // large read so a single pathological artifact can't take the process down.
+    if bom_size > MAX_REPARSE_BOM_BYTES {
+        tracing::warn!(
+            "reparse: [{pos}/{total}] board={id} skipped: bom json {bom_size} bytes exceeds {MAX_REPARSE_BOM_BYTES} byte probe limit"
+        );
+        let _ = std::io::stdout().flush();
+        return ReparseResult::Current;
+    }
+
+    // Load just the parser_version field
     let json_bytes = match s3.get_object(&bom_key).await {
         Ok(b) => b,
         Err(_) => return ReparseResult::Failed("could not read bom json".into()),
@@ -166,6 +197,13 @@ async fn check_and_reparse(s3: &S3Client, id: &str, pos: usize, total: usize) ->
         .next()
         .unwrap_or("upload.bin")
         .to_string();
+
+    // Skip formats no longer served. Legacy GDSII records predate the stored `format`
+    // field, so the probe check above can't catch them; detect by upload extension and
+    // skip before attempting a parse that detect_format would only drop anyway.
+    if is_unsupported_upload(&filename) {
+        return ReparseResult::Current;
+    }
 
     // Emit + flush a per-board start line and persist a progress marker BEFORE the
     // memory-spiking download/parse. A SIGKILL/OOM leaves no unwind, so whatever is
@@ -231,4 +269,32 @@ async fn check_and_reparse(s3: &S3Client, id: &str, pos: usize, total: usize) ->
         rss_mb()
     );
     ReparseResult::Reparsed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn skips_legacy_gdsii_uploads_by_extension() {
+        assert!(is_unsupported_upload("sky130_sram_1rw1r_80x64_8.gds"));
+        assert!(is_unsupported_upload("design.GDS"));
+        assert!(is_unsupported_upload("layout.gdsii"));
+        assert!(is_unsupported_upload("uploads/id/chip.Gds"));
+    }
+
+    #[test]
+    fn keeps_supported_uploads() {
+        assert!(!is_unsupported_upload("board.kicad_pcb"));
+        assert!(!is_unsupported_upload("board.brd"));
+        assert!(!is_unsupported_upload("upload.bin"));
+        assert!(!is_unsupported_upload("no_extension"));
+    }
+
+    #[test]
+    fn size_guard_rejects_only_degenerate_boms() {
+        // A real PCB bom (a few MB) is probed; a 1.23 GB legacy GDSII artifact is not.
+        assert!(5 * 1024 * 1024 <= MAX_REPARSE_BOM_BYTES);
+        assert!(1_291_972_963 > MAX_REPARSE_BOM_BYTES);
+    }
 }


### PR DESCRIPTION
Closes #55. Fixes the crash-loop diagnosed in #266 (culprit board identified by the #263/#264 telemetry).

## Problem

`check_and_reparse` reads each stored bom JSON **fully into memory** and runs `serde_json` over it just to probe two fields (`parser_version`, `format`). Board `b7deeef5` — a 4.3 MB legacy GDSII upload whose stored bom JSON is **1.23 GB** — blows past the container's 2 GB limit. RSS jumps ~481 MB → 2 GB in ~1s on that one `get_object`, the kernel SIGKILLs the process (`exit 137`), it restarts from index 1, and re-reaches the same board forever (~every 3.5 min).

The existing `format == Gdsii` skip can't catch it: these records predate the `format` field, and it fires *after* the fatal download anyway.

## Fix

- **Size guard (the real fix).** Skip probing any bom over **256 MB**, using the size already returned by the top-level `boms/` listing — **no extra request**. This prevents *any* single pathological artifact (GDSII or not) from OOM-killing the process, not just today's board. The issue notes 14 boms already exceed 200 MB (next largest 391 MB); a real PCB bom is a few MB, so 256 MB only ever rejects degenerate records. Skipped boms are named in a flushed `warn` line.
- **Legacy GDSII skip by upload extension.** Detect `.gds`/`.gdsii` from the upload filename and skip before attempting a parse `detect_format` would only drop. Removes the ~184 pointless start lines per scan.

## On the marker note in #266

#266 suggested moving the `reparse_progress` marker above the bom fetch so the next OOM self-identifies. With the size guard the bom fetch can no longer OOM (oversized boms are skipped *before* any read, and named in the log), so the marker stays where it is — covering the remaining spike point, the upload parse.

## Not included (follow-ups from #266)

- Deleting the oversized legacy GDSII boms outright (format no longer served).
- Investigating why a 4.3 MB GDS expanded to 1.23 GB of bom JSON in the first place.

## Testing

Unit tests for the extension predicate and the size threshold. `cargo test -p pastebom-server` — 26 passed; clippy clean.

Once merged and deployed, the ops `SKIP_REPARSE=1` mitigation can be removed.