### PR TITLE
Add viewer back button and card-style recent feed

### DIFF
--- a/crates/server/static/index.html
+++ b/crates/server/static/index.html
@@ -147,37 +147,66 @@
             font-size: 1.1rem;
             margin: 0 0 1rem 0;
         }
-        .public-table {
-            width: 100%;
-            border-collapse: collapse;
-            font-size: 0.85rem;
+        .paste-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+            gap: 1rem;
+            margin-top: 1rem;
         }
-        .public-table th {
-            text-align: left;
-            color: #888;
-            font-weight: 500;
-            padding: 0.5rem 0.5rem;
-            border-bottom: 1px solid #2a2a4e;
-        }
-        .public-table td {
-            padding: 0.5rem 0.5rem;
-            border-bottom: 1px solid #2a2a4e;
-        }
-        .public-table tr:last-child td { border-bottom: none; }
-        .public-table td a {
-            color: #4ecca3;
-            text-decoration: none;
+        .paste-card {
+            position: relative;
             display: block;
-            max-width: 300px;
+            aspect-ratio: 4 / 3;
+            border-radius: 10px;
+            overflow: hidden;
+            background: #0f1626;
+            border: 1px solid #2a2a4e;
+            text-decoration: none;
+            transition: transform 0.15s, border-color 0.15s, box-shadow 0.15s;
+        }
+        .paste-card:hover {
+            transform: translateY(-2px);
+            border-color: #4ecca3;
+            box-shadow: 0 6px 18px rgba(0, 0, 0, 0.35);
+        }
+        .paste-card-thumb {
+            position: absolute;
+            inset: 0;
+            width: 100%;
+            height: 100%;
+            object-fit: contain;
+            padding: 10px;
+            opacity: 0.4;
+            transition: opacity 0.15s;
+        }
+        .paste-card:hover .paste-card-thumb { opacity: 0.7; }
+        .paste-card-overlay {
+            position: absolute;
+            inset: 0;
+            display: flex;
+            flex-direction: column;
+            justify-content: flex-end;
+            padding: 0.75rem;
+            background: linear-gradient(to top,
+                rgba(15, 22, 38, 0.95) 0%,
+                rgba(15, 22, 38, 0.6) 38%,
+                rgba(15, 22, 38, 0.1) 68%,
+                rgba(15, 22, 38, 0) 100%);
+        }
+        .paste-card-name {
+            color: #eee;
+            font-weight: 600;
+            font-size: 0.9rem;
             overflow: hidden;
             text-overflow: ellipsis;
             white-space: nowrap;
         }
-        .public-table td a:hover { text-decoration: underline; }
-        .public-table .num { text-align: right; color: #aaa; }
-        .public-table .age { color: #666; white-space: nowrap; }
-        .thumb-cell { width: 60px; padding: 0.25rem 0.5rem; }
-        .thumb-img { width: 56px; height: auto; border-radius: 4px; border: 1px solid #2a2a4e; vertical-align: middle; }
+        .paste-card:hover .paste-card-name { color: #7effc3; }
+        .paste-card-meta {
+            color: #9aa8bf;
+            font-size: 0.75rem;
+            margin-top: 0.3rem;
+        }
     </style>
 </head>
 <body>
@@ -294,32 +323,23 @@
                 const resp = await fetch('/api/recent');
                 const entries = await resp.json();
                 if (!entries.length) { recentEl.innerHTML = ''; return; }
-                const rows = entries.map(e => {
+                const cards = entries.map(e => {
                     const ago = timeAgo(e.created);
                     const size = e.file_size != null ? formatSize(e.file_size) : '';
                     const fmt = detectFormat(e.filename);
-                    return `<tr>
-                        <td class="thumb-cell"><a href="/b/${e.id}" target="_blank"><img src="/b/${e.id}/thumb.svg" class="thumb-img" loading="lazy" alt=""></a></td>
-                        <td><a href="/b/${e.id}" target="_blank">${e.filename}</a></td>
-                        <td>${fmt}</td>
-                        <td class="num">${e.components}</td>
-                        <td class="num">${size}</td>
-                        <td class="age">${ago}</td>
-                    </tr>`;
+                    const meta = [fmt, e.components != null ? `${e.components} comps` : '', size, ago]
+                        .filter(Boolean).join(' · ');
+                    return `<a class="paste-card" href="/b/${e.id}" target="_blank">
+                        <img class="paste-card-thumb" src="/b/${e.id}/thumb.svg" loading="lazy" alt="">
+                        <div class="paste-card-overlay">
+                            <div class="paste-card-name">${e.filename}</div>
+                            <div class="paste-card-meta">${meta}</div>
+                        </div>
+                    </a>`;
                 }).join('');
                 recentEl.innerHTML = `
                     <h2>Public Pastes</h2>
-                    <table class="public-table">
-                        <thead><tr>
-                            <th></th>
-                            <th>Name</th>
-                            <th>Format</th>
-                            <th class="num">Components</th>
-                            <th class="num">Size</th>
-                            <th>Age</th>
-                        </tr></thead>
-                        <tbody>${rows}</tbody>
-                    </table>`;
+                    <div class="paste-grid">${cards}</div>`;
             } catch { recentEl.innerHTML = ''; }
         }
         loadRecent();

--- a/crates/viewer/src/main.rs
+++ b/crates/viewer/src/main.rs
@@ -888,7 +888,8 @@ fn app() -> Html {
             // ─── BOM sidebar (left) ────────────────────────────
                 <div class={classes!("sidebar", "bom-sidebar", (!*bom_sidebar_open).then_some("sidebar-closed"))}>
                     <div class="sidebar-header">
-                        <div>
+                        <a class="back-btn" href="/" title="Back to PasteBOM" aria-label="Back to PasteBOM">{"\u{2039}"}</a>
+                        <div class="sidebar-header-titles">
                             <div class="sidebar-title">{
                                 if let Some(ref name) = *upload_filename {
                                     name.clone()

--- a/crates/viewer/style.css
+++ b/crates/viewer/style.css
@@ -179,8 +179,8 @@ body {
 
 .sidebar-header {
   display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
   padding: 12px 16px;
   border-bottom: 1px solid rgba(0, 0, 0, 0.1);
   flex-shrink: 0;
@@ -189,6 +189,44 @@ body {
 
 .dark .sidebar-header {
   border-bottom-color: rgba(255, 255, 255, 0.1);
+}
+
+.sidebar-header-titles {
+  min-width: 0;
+  flex: 1;
+}
+
+.back-btn {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  background: rgba(0, 0, 0, 0.05);
+  color: inherit;
+  text-decoration: none;
+  font-size: 22px;
+  font-weight: bold;
+  line-height: 1;
+  padding-bottom: 2px;
+  cursor: pointer;
+  transition: background 0.2s, border-color 0.2s;
+}
+
+.back-btn:hover {
+  background: rgba(0, 0, 0, 0.1);
+}
+
+.dark .back-btn {
+  border-color: rgba(255, 255, 255, 0.15);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.dark .back-btn:hover {
+  background: rgba(255, 255, 255, 0.16);
 }
 
 .sidebar-title {


### PR DESCRIPTION
Two front-end changes.

## Board viewer — back button
Adds a back-to-home button (`‹`) at the left of the BOM sidebar header — the viewer's title/nav bar — so there's an obvious way back to the upload page from a board. Links to `/`.

## Landing page — card-style recent feed
Replaces the "Public Pastes" table with a responsive card grid: each paste is a larger thumbnail dimmed in the background, with the filename and metadata (format · components · size · age) overlaid on a gradient scrim. Hovering brightens the thumbnail and lifts the card.

## Verification
- Viewer compiles for `wasm32-unknown-unknown`; built with trunk and rendered against a local board — back button shows in the header, board renders normally.
- Recent grid rendered with real thumbnails in headless Chrome.

## Note
The back button lives in the BOM sidebar header, so on mobile (where that panel starts collapsed) it appears once the panel is opened. Happy to make it a always-visible floating control instead if you'd prefer.